### PR TITLE
Initialize npm and document start

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Pagian Web Fashion
+
+Este proyecto utiliza un pequeño servidor en Express para servir el contenido.
+
+## Uso
+
+1. Instale las dependencias con `npm install`.
+2. Inicie el servidor ejecutando:
+
+```bash
+npm start
+```
+
+El comando inicia `js/server.js`, que expone la aplicación en [http://localhost:8080](http://localhost:8080).

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "pagianwebfashion",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node js/server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- initialize npm project
- add start script to run the server
- document how to launch the Express server in Spanish

## Testing
- `npm init -y`
- `npm install express` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68645e02437883229ad30ade62f2e9c3