### PR TITLE
Fix cart sync and quantity styles

### DIFF
--- a/acero.html
+++ b/acero.html
@@ -61,6 +61,12 @@
             background-color: rgba(255, 255, 255, 0.95);
             box-shadow: 0 2px 10px rgba(0,0,0,0.1);
         }
+        .quantity-input {
+            max-width: 70px;
+            text-align: center;
+            border-radius: 20px;
+            border: 1px solid var(--primary-color);
+        }
     </style>
 </head>
 <body>
@@ -213,7 +219,7 @@
             const qtyInput = document.getElementById('qty-' + productId);
             const qty = parseInt(qtyInput ? qtyInput.value : '1', 10) || 1;
 
-            let cart = JSON.parse(localStorage.getItem('cart') || '[]');
+            let cart = JSON.parse(localStorage.getItem('fashionCart') || '[]');
             const product = allProducts.find(p => p.id === productId) || {};
             const existingItem = cart.find(item => item.id === productId);
 
@@ -229,7 +235,7 @@
                 });
             }
 
-            localStorage.setItem('cart', JSON.stringify(cart));
+            localStorage.setItem('fashionCart', JSON.stringify(cart));
 
             Swal.fire({
                 icon: 'success',
@@ -243,14 +249,14 @@
         }
 
         function updateCartCounter() {
-            const cart = JSON.parse(localStorage.getItem('cart') || '[]');
+            const cart = JSON.parse(localStorage.getItem('fashionCart') || '[]');
             const totalItems = cart.reduce((sum, item) => sum + item.quantity, 0);
 
-            const cartCounter = document.querySelector('.cart-counter');
-            if (cartCounter) {
-                cartCounter.textContent = totalItems;
-                cartCounter.style.display = totalItems > 0 ? 'inline' : 'none';
-            }
+            const badges = document.querySelectorAll('.cart-badge, .cart-counter, .cart-count');
+            badges.forEach(el => {
+                el.textContent = totalItems;
+                el.style.display = totalItems > 0 ? 'inline' : 'none';
+            });
         }
     </script>
 </body>

--- a/acrilico.html
+++ b/acrilico.html
@@ -69,6 +69,12 @@
             box-shadow: 0 2px 10px rgba(0,0,0,0.05);
             margin-bottom: 2rem;
         }
+        .quantity-input {
+            max-width: 70px;
+            text-align: center;
+            border-radius: 20px;
+            border: 1px solid #ff6b6b;
+        }
     </style>
 </head>
 <body>
@@ -352,7 +358,7 @@
             if (!product) return;
 
             // Obtener carrito actual
-            let cart = JSON.parse(localStorage.getItem('cart') || '[]');
+            let cart = JSON.parse(localStorage.getItem('fashionCart') || '[]');
             
             // Verificar si ya existe
             const qtyInput = document.getElementById('qty-' + productId);
@@ -373,7 +379,7 @@
             }
             
             // Guardar carrito
-            localStorage.setItem('cart', JSON.stringify(cart));
+            localStorage.setItem('fashionCart', JSON.stringify(cart));
             
             // Mostrar notificación con SweetAlert
             Swal.fire({
@@ -389,14 +395,14 @@
         }
 
         function updateCartCounter() {
-            const cart = JSON.parse(localStorage.getItem('cart') || '[]');
+            const cart = JSON.parse(localStorage.getItem('fashionCart') || '[]');
             const totalItems = cart.reduce((sum, item) => sum + item.quantity, 0);
             
-            const cartCounter = document.querySelector('.cart-counter');
-            if (cartCounter) {
-                cartCounter.textContent = totalItems;
-                cartCounter.style.display = totalItems > 0 ? 'inline' : 'none';
-            }
+            const badges = document.querySelectorAll('.cart-badge, .cart-counter, .cart-count');
+            badges.forEach(el => {
+                el.textContent = totalItems;
+                el.style.display = totalItems > 0 ? 'inline' : 'none';
+            });
         }
 
         // Actualizar contador al cargar

--- a/bisuteria.html
+++ b/bisuteria.html
@@ -95,6 +95,12 @@
             box-shadow: 0 2px 10px rgba(0,0,0,0.05);
             margin-bottom: 2rem;
         }
+        .quantity-input {
+            max-width: 70px;
+            text-align: center;
+            border-radius: 20px;
+            border: 1px solid var(--primary-color);
+        }
         .sort-dropdown .dropdown-menu {
             width: 100%;
         }
@@ -398,7 +404,7 @@
             if (!product) return;
 
             // Obtener carrito actual del localStorage
-            let cart = JSON.parse(localStorage.getItem('cart') || '[]');
+            let cart = JSON.parse(localStorage.getItem('fashionCart') || '[]');
             
             // Verificar si el producto ya está en el carrito
             const qtyInput = document.getElementById('qty-' + productId);
@@ -419,7 +425,7 @@
             }
             
             // Guardar carrito actualizado
-            localStorage.setItem('cart', JSON.stringify(cart));
+            localStorage.setItem('fashionCart', JSON.stringify(cart));
             
             // Mostrar notificación con SweetAlert
             Swal.fire({
@@ -436,14 +442,14 @@
 
         // Función para actualizar contador del carrito
         function updateCartCounter() {
-            const cart = JSON.parse(localStorage.getItem('cart') || '[]');
+            const cart = JSON.parse(localStorage.getItem('fashionCart') || '[]');
             const totalItems = cart.reduce((sum, item) => sum + item.quantity, 0);
             
-            const cartCounter = document.querySelector('.cart-counter');
-            if (cartCounter) {
-                cartCounter.textContent = totalItems;
-                cartCounter.style.display = totalItems > 0 ? 'inline' : 'none';
-            }
+            const badges = document.querySelectorAll('.cart-badge, .cart-counter, .cart-count');
+            badges.forEach(el => {
+                el.textContent = totalItems;
+                el.style.display = totalItems > 0 ? 'inline' : 'none';
+            });
         }
 
         // Actualizar contador al cargar la página

--- a/js/cart-enhanced.js
+++ b/js/cart-enhanced.js
@@ -9,7 +9,7 @@ class EnhancedCart {
     // Cargar carrito desde localStorage
     loadCart() {
         try {
-            const cartData = localStorage.getItem('cart');
+            const cartData = localStorage.getItem('fashionCart');
             return cartData ? JSON.parse(cartData) : [];
         } catch (error) {
             console.error('Error cargando carrito:', error);
@@ -20,7 +20,7 @@ class EnhancedCart {
     // Guardar carrito en localStorage
     saveCart() {
         try {
-            localStorage.setItem('cart', JSON.stringify(this.cart));
+            localStorage.setItem('fashionCart', JSON.stringify(this.cart));
             this.updateCartDisplay();
         } catch (error) {
             console.error('Error guardando carrito:', error);
@@ -360,7 +360,7 @@ class EnhancedCart {
     initializeEventListeners() {
         // Escuchar cambios en el localStorage para sincronizar entre pestañas
         window.addEventListener('storage', (e) => {
-            if (e.key === 'cart') {
+            if (e.key === 'fashionCart') {
                 this.cart = this.loadCart();
                 this.updateCartDisplay();
             }

--- a/maquillaje.html
+++ b/maquillaje.html
@@ -98,6 +98,12 @@
         .sort-dropdown .dropdown-menu {
             width: 100%;
         }
+        .quantity-input {
+            max-width: 70px;
+            text-align: center;
+            border-radius: 20px;
+            border: 1px solid var(--primary-color);
+        }
     </style>
 </head>
 <body>
@@ -444,7 +450,7 @@
             if (!product) return;
 
             // Obtener carrito actual del localStorage
-            let cart = JSON.parse(localStorage.getItem('cart') || '[]');
+            let cart = JSON.parse(localStorage.getItem('fashionCart') || '[]');
             
             // Verificar si el producto ya está en el carrito
             const qtyInput = document.getElementById('qty-' + productId);
@@ -465,7 +471,7 @@
             }
             
             // Guardar carrito actualizado
-            localStorage.setItem('cart', JSON.stringify(cart));
+            localStorage.setItem('fashionCart', JSON.stringify(cart));
             
             // Mostrar notificación con SweetAlert
             Swal.fire({
@@ -482,14 +488,14 @@
 
         // Función para actualizar contador del carrito
         function updateCartCounter() {
-            const cart = JSON.parse(localStorage.getItem('cart') || '[]');
+            const cart = JSON.parse(localStorage.getItem('fashionCart') || '[]');
             const totalItems = cart.reduce((sum, item) => sum + item.quantity, 0);
             
-            const cartCounter = document.querySelector('.cart-counter');
-            if (cartCounter) {
-                cartCounter.textContent = totalItems;
-                cartCounter.style.display = totalItems > 0 ? 'inline' : 'none';
-            }
+            const badges = document.querySelectorAll('.cart-badge, .cart-counter, .cart-count');
+            badges.forEach(el => {
+                el.textContent = totalItems;
+                el.style.display = totalItems > 0 ? 'inline' : 'none';
+            });
         }
 
         // Actualizar contador al cargar la página

--- a/novedades.html
+++ b/novedades.html
@@ -90,6 +90,12 @@
             box-shadow: 0 2px 10px rgba(0,0,0,0.05);
             margin-bottom: 2rem;
         }
+        .quantity-input {
+            max-width: 70px;
+            text-align: center;
+            border-radius: 20px;
+            border: 1px solid #28a745;
+        }
         .trending-section {
             background: linear-gradient(45deg, #28a745, #20c997);
             color: white;
@@ -470,7 +476,7 @@ function addToCart(productId) {
             if (!product) return;
 
             // Obtener carrito actual
-            let cart = JSON.parse(localStorage.getItem('cart') || '[]');
+            let cart = JSON.parse(localStorage.getItem('fashionCart') || '[]');
             
             // Verificar si ya existe
             const qtyInput = document.getElementById('qty-' + productId);
@@ -492,7 +498,7 @@ function addToCart(productId) {
             }
             
             // Guardar carrito
-            localStorage.setItem('cart', JSON.stringify(cart));
+            localStorage.setItem('fashionCart', JSON.stringify(cart));
             
             // Mostrar notificación con SweetAlert
             Swal.fire({
@@ -522,14 +528,14 @@ function addToCart(productId) {
         }
 
         function updateCartCounter() {
-            const cart = JSON.parse(localStorage.getItem('cart') || '[]');
+            const cart = JSON.parse(localStorage.getItem('fashionCart') || '[]');
             const totalItems = cart.reduce((sum, item) => sum + item.quantity, 0);
             
-            const cartCounter = document.querySelector('.cart-counter');
-            if (cartCounter) {
-                cartCounter.textContent = totalItems;
-                cartCounter.style.display = totalItems > 0 ? 'inline' : 'none';
-            }
+            const badges = document.querySelectorAll('.cart-badge, .cart-counter, .cart-count');
+            badges.forEach(el => {
+                el.textContent = totalItems;
+                el.style.display = totalItems > 0 ? 'inline' : 'none';
+            });
         }
 
         // Actualizar contador al cargar

--- a/ofertas.html
+++ b/ofertas.html
@@ -100,6 +100,12 @@
             box-shadow: 0 2px 10px rgba(0,0,0,0.05);
             margin-bottom: 2rem;
         }
+        .quantity-input {
+            max-width: 70px;
+            text-align: center;
+            border-radius: 20px;
+            border: 1px solid #ff6b6b;
+        }
         .countdown-timer {
             background: linear-gradient(45deg, #ff6b6b, #ee5a24);
             color: white;
@@ -451,7 +457,7 @@
             if (!product) return;
 
             // Obtener carrito actual
-            let cart = JSON.parse(localStorage.getItem('cart') || '[]');
+            let cart = JSON.parse(localStorage.getItem('fashionCart') || '[]');
             
             // Verificar si ya existe
             const qtyInput = document.getElementById('qty-' + productId);
@@ -474,7 +480,7 @@
             }
             
             // Guardar carrito
-            localStorage.setItem('cart', JSON.stringify(cart));
+            localStorage.setItem('fashionCart', JSON.stringify(cart));
             
             // Mostrar notificación con SweetAlert
             Swal.fire({
@@ -490,14 +496,14 @@
         }
 
         function updateCartCounter() {
-            const cart = JSON.parse(localStorage.getItem('cart') || '[]');
+            const cart = JSON.parse(localStorage.getItem('fashionCart') || '[]');
             const totalItems = cart.reduce((sum, item) => sum + item.quantity, 0);
             
-            const cartCounter = document.querySelector('.cart-counter');
-            if (cartCounter) {
-                cartCounter.textContent = totalItems;
-                cartCounter.style.display = totalItems > 0 ? 'inline' : 'none';
-            }
+            const badges = document.querySelectorAll('.cart-badge, .cart-counter, .cart-count');
+            badges.forEach(el => {
+                el.textContent = totalItems;
+                el.style.display = totalItems > 0 ? 'inline' : 'none';
+            });
         }
 
         function startCountdown() {


### PR DESCRIPTION
## Summary
- ensure product pages use the same `fashionCart` storage key
- update cart counters on pages to target `.cart-badge` elements
- add minimal styling for quantity fields
- keep cart enhanced script in sync with new storage key

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686463f3d77c8322b883bb73d8cf02ac