### PR TITLE
Fix shipping calculation and invoice messages

### DIFF
--- a/carrito.html
+++ b/carrito.html
@@ -240,16 +240,16 @@
                     <h3 class="summary-title emoji-title"><span>📦</span>Resumen del Pedido</h3>
                     <div class="summary-item">
                         <span>Subtotal</span>
-                        <span>L0.00</span>
+                        <span id="cart-subtotal">L0.00</span>
                     </div>
                     <div class="summary-item">
                         <span>Envío</span>
-                        <span>L120.00</span>
+                        <span id="cart-shipping">L120.00</span>
                     </div>
                     <hr>
                     <div class="summary-item grand-total">
                         <span>Total</span>
-                        <span>L0.00</span>
+                        <span id="cart-total">L0.00</span>
                     </div>
                     <button id="checkout-btn" class="btn btn-primary checkout-btn w-100 mt-4">
                         <i class="fas fa-lock me-2"></i>Proceder al Pago 💳

--- a/js/cart.js
+++ b/js/cart.js
@@ -5,7 +5,8 @@ document.addEventListener('DOMContentLoaded', () => {
     // Variables globales
     let cartItems = [];
     let subtotal = 0;
-    let shipping = 120.00;
+    const SHIPPING_RATE = 120.00; // costo de envío por artículo
+    let shipping = 0;
     let total = 0;
 
     // Inicializar si estamos en página de carrito (soporta rutas sin extensión)
@@ -240,6 +241,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Actualizar totales del carrito con formato hondureño
     function updateCartTotals(discount = 0) {
+        const totalItems = cartItems.reduce((sum, item) => sum + item.quantity, 0);
+        shipping = SHIPPING_RATE * totalItems;
         subtotal = cartItems.reduce((sum, item) => sum + (item.price * item.quantity), 0);
         total = subtotal + shipping - discount;
 
@@ -395,34 +398,36 @@ document.addEventListener('DOMContentLoaded', () => {
     function sendOrderToWhatsApp(order, savedOrderId = null) {
         const phoneNumber = '50494859196'; // Número de WhatsApp de Honduras
         
-        // Formatear mensaje 
-        let message = `🛍️ *🛍️NUEVO PEDIDO - Fashion Collection Honduras*\n\n`;
-        message += `👤 Cliente: ${order.userName}\n`;
-        message += `📧 Email: ${order.userEmail}\n`;
-        message += `📅 Fecha: ${formatDateHonduras(new Date())}\n`;
-        message += `🆔 ID Pedido: #${order.id.substring(0, 8)}\n`;
+        // Formatear mensaje en estilo de factura
+        let message = `🧾 *Factura de Pedido - Fashion Collection* 🧾\n\n`;
+        message += `👤 *Cliente:* ${order.userName}\n`;
+        message += `📧 *Correo:* ${order.userEmail}\n`;
+        message += `🗓️ *Fecha:* ${formatDateHonduras(new Date())}\n`;
+        message += `🆔 *Pedido:* #${order.id.substring(0, 8)}\n`;
         if (savedOrderId) {
-            message += `💾 ID Sistema: ${savedOrderId}\n`;
+            message += `🔑 *ID Sistema:* ${savedOrderId}\n`;
         }
-        message += `\n`;
-        
-        message += `📦 *PRODUCTOS SOLICITADOS:*\n`;
+        message += `------------------------------\n`;
+
+        message += `*Detalle de Productos*\n`;
         order.items.forEach((item, index) => {
             const itemTotal = item.price * item.quantity;
             message += `${index + 1}. ${item.name}\n`;
-            message += `   💰 L. ${formatCurrencyHonduras(item.price)} x ${item.quantity} = L. ${formatCurrencyHonduras(itemTotal)}\n\n`;
+            message += `   Precio: L. ${formatCurrencyHonduras(item.price)}\n`;
+            message += `   Cantidad: ${item.quantity}\n`;
+            message += `   Subtotal: L. ${formatCurrencyHonduras(itemTotal)}\n`;
         });
-        
-        message += `📊 *RESUMEN DEL PEDIDO:*\n`;
+
+        message += `------------------------------\n`;
+        message += `*Resumen*\n`;
         message += `Subtotal: L. ${formatCurrencyHonduras(order.subtotal)}\n`;
         message += `Envío: L. ${formatCurrencyHonduras(order.shipping)}\n`;
-        message += `💵 *TOTAL A PAGAR: L. ${formatCurrencyHonduras(order.total)}*\n\n`;
-        
-        message += `🇭🇳 *INFORMACIÓN DE ENTREGA:*\n`;
-        message += `📍 Por favor confirma tu dirección completa en Honduras\n`;
-        message += `💳 Método de pago preferido (Efectivo/Transferencia)\n`;
+        message += `*TOTAL: L. ${formatCurrencyHonduras(order.total)}*\n\n`;
+
+        message += `📍 Confirma tu dirección de entrega en Honduras\n`;
+        message += `💳 Forma de pago: Efectivo o Transferencia\n`;
         message += `📞 Número de contacto para coordinar entrega\n\n`;
-        
+
         message += `✅ Pedido realizado desde: ${window.location.origin}\n`;
         message += `🕒 Horario de atención: Lunes a Sábado 8:00 AM - 5:30 PM`;
         


### PR DESCRIPTION
## Summary
- recalculate shipping based on item quantities
- keep WhatsApp message in invoice style

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68646e27c3d48322ae0c263537ff953f