### PR TITLE
Improve admin tasks and add contact messages

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -1334,6 +1334,7 @@
 
     <!-- Application Scripts -->
     <script type="module" src="js/admin-tareas-funcionales.js"></script>
+    <script type="module" src="js/messages.js"></script>
     <script type="module" src="js/firebase-config.js"></script>
     <script type="module" src="js/auth.js"></script>
     <script type="module" src="js/reports.js"></script>

--- a/contacto.html
+++ b/contacto.html
@@ -611,5 +611,11 @@
     </div>
 </section>
 
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
+    <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/8.10.1/firebase-firestore.js"></script>
+    <script src="js/firebase-config.js"></script>
+    <script src="js/contact.js"></script>
 </body>
 </html>

--- a/js/admin-tareas-funcionales.js
+++ b/js/admin-tareas-funcionales.js
@@ -26,6 +26,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 <td>${new Date(tarea.fecha.toDate()).toLocaleString()}</td>
                 <td>
                     <button class="btn btn-sm btn-success ejecutar-tarea" data-id="${tarea.id}">Ejecutar</button>
+                    <button class="btn btn-sm btn-danger eliminar-tarea ms-1" data-id="${tarea.id}">Eliminar</button>
                 </td>
             </tr>
         `).join('');
@@ -43,6 +44,32 @@ document.addEventListener('DOMContentLoaded', () => {
         ejecutarTarea(tarea);
     });
 
+    // Evento para eliminar tarea
+    document.addEventListener('click', async (e) => {
+        const btn = e.target.closest('.eliminar-tarea');
+        if (!btn) return;
+
+        const tareaId = btn.dataset.id;
+        const confirm = await Swal.fire({
+            title: '¿Eliminar tarea?',
+            icon: 'warning',
+            showCancelButton: true,
+            confirmButtonText: 'Sí, eliminar',
+            cancelButtonText: 'Cancelar',
+            confirmButtonColor: '#dc3545'
+        });
+        if (!confirm.isConfirmed) return;
+
+        try {
+            await firebase.firestore().collection('tareas').doc(tareaId).delete();
+            Swal.fire({ icon: 'success', title: 'Tarea eliminada' });
+            cargarTareas();
+        } catch (error) {
+            console.error('Error eliminando tarea:', error);
+            Swal.fire({ icon: 'error', title: 'No se pudo eliminar la tarea' });
+        }
+    });
+
     // Función para ejecutar tareas según tipo
     async function ejecutarTarea(tarea) {
         try {
@@ -51,24 +78,24 @@ document.addEventListener('DOMContentLoaded', () => {
                     await firebase.firestore().collection('products').doc(tarea.productoId).update({
                         price: tarea.nuevoPrecio
                     });
-                    alert(`✅ Precio actualizado a L.${tarea.nuevoPrecio}`);
+                    Swal.fire({ icon: 'success', title: `Precio actualizado a L.${tarea.nuevoPrecio}` });
                     break;
                 case 'cambiar_stock':
                     await firebase.firestore().collection('products').doc(tarea.productoId).update({
                         stock: tarea.nuevoStock
                     });
-                    alert(`✅ Stock actualizado a ${tarea.nuevoStock}`);
+                    Swal.fire({ icon: 'success', title: `Stock actualizado a ${tarea.nuevoStock}` });
                     break;
                 case 'eliminar_producto':
                     await firebase.firestore().collection('products').doc(tarea.productoId).delete();
-                    alert('🗑️ Producto eliminado exitosamente');
+                    Swal.fire({ icon: 'success', title: 'Producto eliminado exitosamente' });
                     break;
                 default:
-                    alert('❌ Tipo de tarea no reconocido');
+                    Swal.fire({ icon: 'error', title: 'Tipo de tarea no reconocido' });
             }
         } catch (error) {
             console.error('Error ejecutando tarea:', error);
-            alert('❌ Error al ejecutar la tarea');
+            Swal.fire({ icon: 'error', title: 'Error al ejecutar la tarea' });
         }
     }
 
@@ -116,10 +143,10 @@ document.getElementById('formTarea').addEventListener('submit', async (e) => {
         await firebase.firestore().collection('tareas').add(nuevaTarea);
         form.reset();
         bootstrap.Modal.getInstance(document.getElementById('modalAgregarTarea')).hide();
-        alert('✅ Tarea guardada correctamente');
+        Swal.fire({ icon: 'success', title: 'Tarea guardada correctamente' });
         cargarTareas(); // recargar tabla
     } catch (error) {
         console.error('Error guardando tarea:', error);
-        alert('❌ No se pudo guardar la tarea');
+        Swal.fire({ icon: 'error', title: 'No se pudo guardar la tarea' });
     }
 });

--- a/js/admin.js
+++ b/js/admin.js
@@ -348,6 +348,7 @@ document.addEventListener("DOMContentLoaded", () => {
       users: 'Usuarios',
       inventory: 'Inventario',
       reports: 'Reportes',
+      messages: 'Mensajes',
       settings: 'Configuración'
     };
     
@@ -378,6 +379,9 @@ document.addEventListener("DOMContentLoaded", () => {
         break;
       case 'reports':
         loadReportsSection();
+        break;
+      case 'messages':
+        window.loadMessages && loadMessages();
         break;
     }
   }

--- a/js/app.js
+++ b/js/app.js
@@ -255,7 +255,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 const bsToast = new bootstrap.Toast(toast);
                 bsToast.show();
             } else {
-                alert(message);
+                if (typeof Swal !== 'undefined') {
+                    Swal.fire({ icon: type, title: message });
+                }
             }
         }
     }

--- a/js/auth.js
+++ b/js/auth.js
@@ -24,7 +24,9 @@ document.addEventListener("DOMContentLoaded", () => {
         position: "top-end",
       });
     } else {
-      alert(message);
+      if (typeof Swal !== 'undefined') {
+        Swal.fire({ icon: type, title: message });
+      }
     }
   };
 

--- a/js/carrito.js
+++ b/js/carrito.js
@@ -88,10 +88,10 @@ document.addEventListener('DOMContentLoaded', function() {
     // Procesar pago
     document.getElementById('checkout-btn').addEventListener('click', function() {
         if (cartItems.length === 0) {
-            alert('Tu carrito está vacío');
+            Swal.fire({ icon: 'info', title: 'Tu carrito está vacío' });
             return;
         }
-        alert('Redirigiendo a pasarela de pago...');
+        Swal.fire({ icon: 'info', title: 'Redirigiendo a pasarela de pago...' });
         // Aquí iría la lógica real de pago
     });
 

--- a/js/cart.js
+++ b/js/cart.js
@@ -5,7 +5,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Variables globales
     let cartItems = [];
     let subtotal = 0;
-    const SHIPPING_RATE = 120.00; // costo de envío por artículo
+    const SHIPPING_RATE = 120.00; // costo de envío fijo
     let shipping = 0;
     let total = 0;
 
@@ -242,7 +242,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Actualizar totales del carrito con formato hondureño
     function updateCartTotals(discount = 0) {
         const totalItems = cartItems.reduce((sum, item) => sum + item.quantity, 0);
-        shipping = SHIPPING_RATE * totalItems;
+        shipping = cartItems.length > 0 ? SHIPPING_RATE : 0;
         subtotal = cartItems.reduce((sum, item) => sum + (item.price * item.quantity), 0);
         total = subtotal + shipping - discount;
 
@@ -475,7 +475,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 position: 'top-end'
             });
         } else {
-            alert(message);
+            if (typeof Swal !== 'undefined') {
+                Swal.fire({ icon: type, title: message });
+            }
         }
     }
 

--- a/js/contact.js
+++ b/js/contact.js
@@ -1,0 +1,24 @@
+// Manejo de formulario de contacto
+document.addEventListener('DOMContentLoaded', () => {
+    const form = document.getElementById('cs-form-1750');
+    if (!form || typeof firebase === 'undefined') return;
+
+    form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const data = {
+            name: form.querySelector('#name-1750').value,
+            email: form.querySelector('#email-1750').value,
+            phone: form.querySelector('#phone-1750').value,
+            message: form.querySelector('#message-1750').value,
+            createdAt: firebase.firestore.FieldValue.serverTimestamp()
+        };
+        try {
+            await firebase.firestore().collection('messages').add(data);
+            Swal.fire({ icon: 'success', title: 'Mensaje enviado correctamente' });
+            form.reset();
+        } catch (err) {
+            console.error('Error enviando mensaje', err);
+            Swal.fire({ icon: 'error', title: 'No se pudo enviar el mensaje' });
+        }
+    });
+});

--- a/js/messages.js
+++ b/js/messages.js
@@ -1,0 +1,20 @@
+// Cargar mensajes de contacto en el panel de admin
+document.addEventListener('DOMContentLoaded', () => {
+    const tableBody = document.querySelector('#messagesTable tbody');
+    if (!tableBody || typeof firebase === 'undefined') return;
+
+    async function loadMessages() {
+        const snapshot = await firebase.firestore()
+            .collection('messages')
+            .orderBy('createdAt', 'desc')
+            .get();
+        const rows = snapshot.docs.map(doc => {
+            const m = doc.data();
+            const fecha = m.createdAt?.seconds ? new Date(m.createdAt.seconds * 1000).toLocaleString() : '';
+            return `<tr><td>${fecha}</td><td>${m.name}</td><td>${m.email}</td><td>${m.message}</td></tr>`;
+        }).join('');
+        tableBody.innerHTML = rows || '<tr><td colspan="4" class="text-center">Sin mensajes</td></tr>';
+    }
+
+    window.loadMessages = loadMessages;
+});

--- a/js/orders.js
+++ b/js/orders.js
@@ -507,7 +507,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 position: 'top-end'
             });
         } else {
-            alert(message);
+            if (typeof Swal !== 'undefined') {
+                Swal.fire({ icon: type, title: message });
+            }
         }
     }
 

--- a/js/products.js
+++ b/js/products.js
@@ -655,7 +655,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 position: 'top-end'
             });
         } else {
-            alert(message);
+            if (typeof Swal !== 'undefined') {
+                Swal.fire({ icon: type, title: message });
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- apply SweetAlert2 across scripts
- adjust shipping calculation for fixed rate
- enhance admin tasks table with delete button
- capture contact form messages in Firestore
- display contact messages in admin panel

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686549de96d483228e774d540533da39