### PR TITLE
Update offer handling

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -520,6 +520,7 @@ async function toggleProductOffer(productId) {
     const product = products.find(p => p.id === productId);
     if (!product) return;
 
+    // Si el producto no está en oferta, solicitar precio y fecha fin
     if (!product.onSale) {
         const { value: price } = await Swal.fire({
             title: 'Precio de oferta',
@@ -530,20 +531,52 @@ async function toggleProductOffer(productId) {
             cancelButtonText: 'Cancelar'
         });
         if (!price) return;
+
+        const { value: endDate } = await Swal.fire({
+            title: 'Fin de la oferta',
+            input: 'datetime-local',
+            showCancelButton: true,
+            confirmButtonText: 'Continuar',
+            cancelButtonText: 'Cancelar'
+        });
+        if (!endDate) return;
+
+        // Guardar datos originales para poder restaurar
         product.originalPrice = product.originalPrice || product.price;
+        product.originalCategory = product.originalCategory || product.category;
+
+        // Actualizar datos de la oferta
         product.price = parseFloat(price);
+        product.category = 'ofertas';
         product.onSale = true;
+        product.offerEndDate = endDate;
     } else {
+        // Restaurar datos originales al quitar la oferta
         product.price = product.originalPrice || product.price;
+        product.category = product.originalCategory || product.category;
         product.onSale = false;
+        delete product.offerEndDate;
     }
 
     if (typeof firebase !== 'undefined' && firebase.firestore) {
-        await firebase.firestore().collection('products').doc(productId).update({
+        const prodRef = firebase.firestore().collection('products').doc(productId);
+        const updateData = {
             onSale: product.onSale,
             price: product.price,
-            originalPrice: product.originalPrice || null
-        });
+            category: product.category
+        };
+
+        if (product.onSale) {
+            updateData.originalPrice = product.originalPrice;
+            updateData.originalCategory = product.originalCategory;
+            updateData.offerEndDate = new Date(product.offerEndDate);
+        } else {
+            updateData.originalPrice = firebase.firestore.FieldValue.delete();
+            updateData.originalCategory = firebase.firestore.FieldValue.delete();
+            updateData.offerEndDate = firebase.firestore.FieldValue.delete();
+        }
+
+        await prodRef.update(updateData);
     }
 
     renderOffersTable();

--- a/js/products.js
+++ b/js/products.js
@@ -61,19 +61,22 @@ document.addEventListener('DOMContentLoaded', () => {
         try {
             const db = firebase.firestore();
             let query = db.collection('products');
-            
+
             if (currentCategory) {
                 query = query.where('category', '==', currentCategory);
             }
-            
+
             const snapshot = await query.get();
             allProducts = snapshot.docs.map(doc => ({
                 id: doc.id,
                 ...doc.data()
             }));
-            
+
             console.log(`📦 ${allProducts.length} productos cargados desde Firebase`);
-            
+
+            // Revisar si hay ofertas vencidas y actualizarlas
+            await handleExpiredOffers(db);
+
         } catch (error) {
             console.error('❌ Error cargando desde Firebase:', error);
             throw error;
@@ -249,6 +252,53 @@ document.addEventListener('DOMContentLoaded', () => {
         }
 
         console.log(`📦 ${allProducts.length} productos demo cargados`);
+
+        // Revisar ofertas vencidas para los datos de demostración
+        handleExpiredOffers();
+    }
+
+    // Verificar si alguna oferta expiró y restaurar categoría y precio
+    async function handleExpiredOffers(db) {
+        const now = new Date();
+        const updates = [];
+
+        allProducts.forEach(product => {
+            if (product.onSale && product.offerEndDate && new Date(product.offerEndDate) <= now) {
+                // Restaurar datos locales
+                product.onSale = false;
+                if (product.originalPrice) {
+                    product.price = product.originalPrice;
+                    delete product.originalPrice;
+                }
+                if (product.originalCategory) {
+                    product.category = product.originalCategory;
+                    delete product.originalCategory;
+                }
+                delete product.offerEndDate;
+
+                // Si tenemos conexión a Firebase, actualizar la base de datos
+                if (db) {
+                    const ref = db.collection('products').doc(product.id);
+                    updates.push(ref.update({
+                        onSale: false,
+                        price: product.price,
+                        category: product.category,
+                        originalPrice: firebase.firestore.FieldValue.delete(),
+                        originalCategory: firebase.firestore.FieldValue.delete(),
+                        offerEndDate: firebase.firestore.FieldValue.delete()
+                    }));
+                }
+            }
+        });
+
+        if (updates.length) {
+            try {
+                await Promise.all(updates);
+                console.log('🔄 Ofertas vencidas actualizadas');
+            } catch (err) {
+                console.error('❌ Error actualizando ofertas vencidas:', err);
+            }
+        }
     }
 
     // Aplicar filtros

--- a/ofertas.html
+++ b/ofertas.html
@@ -319,6 +319,7 @@
                     // Cargar productos en oferta desde Firebase
                     const snapshot = await firebase.firestore()
                         .collection('products')
+                        .where('category', '==', 'ofertas')
                         .where('onSale', '==', true)
                         .get();
 


### PR DESCRIPTION
## Summary
- move on-sale products into the `ofertas` category
- restore price and category when offer ends
- automatically update expired offers
- filter offers page by products in the `ofertas` category

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68655ca938e88322be70ffd80f655285