### PR TITLE
Agregar opciones de envío y cupón al carrito

### DIFF
--- a/carrito.html
+++ b/carrito.html
@@ -244,14 +244,38 @@
                     </div>
                     <div class="summary-item">
                         <span>Envío</span>
-                        <span id="cart-shipping">L120.00</span>
+                        <span id="cart-shipping">L0.00</span>
+                    </div>
+                    <div class="mb-3" id="shipping-options">
+                        <div class="form-check">
+                            <input class="form-check-input" type="radio" name="shipping" id="shipping-sps" value="80" checked>
+                            <label class="form-check-label" for="shipping-sps">San Pedro Sula (L80.00)</label>
+                        </div>
+                        <div class="form-check">
+                            <input class="form-check-input" type="radio" name="shipping" id="shipping-nacional" value="90">
+                            <label class="form-check-label" for="shipping-nacional">Nacional (L90.00)</label>
+                        </div>
+                        <div class="form-check">
+                            <input class="form-check-input" type="radio" name="shipping" id="shipping-tienda" value="0">
+                            <label class="form-check-label" for="shipping-tienda">Recoger en tienda (L0.00)</label>
+                        </div>
+                    </div>
+                    <div class="summary-item" id="discount-row" style="display:none;">
+                        <span>Descuento</span>
+                        <span id="cart-discount">-L0.00</span>
                     </div>
                     <hr>
                     <div class="summary-item grand-total">
                         <span>Total</span>
                         <span id="cart-total">L0.00</span>
                     </div>
-                    <button id="checkout-btn" class="btn btn-primary checkout-btn w-100 mt-4">
+                    <form id="coupon-form" class="input-group mb-3">
+                        <input type="text" id="coupon-code" class="form-control" placeholder="Código de cupón">
+                        <button class="btn btn-outline-secondary" type="submit">Aplicar</button>
+                    </form>
+                    <p class="text-danger small" id="coupon-msg"></p>
+                    <button id="update-cart-btn" class="btn btn-secondary w-100 mb-2">Actualizar carrito</button>
+                    <button id="checkout-btn" class="btn btn-primary checkout-btn w-100 mt-2">
                         <i class="fas fa-lock me-2"></i>Proceder al Pago 💳
                     </button>
                     <div class="text-center mt-3">

--- a/js/cart.js
+++ b/js/cart.js
@@ -5,8 +5,15 @@ document.addEventListener('DOMContentLoaded', () => {
     // Variables globales
     let cartItems = [];
     let subtotal = 0;
-    const SHIPPING_RATE = 120.00; // costo de envío fijo
+    const SHIPPING_OPTIONS = {
+        sps: 80.00,
+        nacional: 90.00,
+        tienda: 0.00
+    };
+    let selectedShipping = SHIPPING_OPTIONS.sps;
     let shipping = 0;
+    let couponDiscount = 0;
+    let orderNumber = parseInt(localStorage.getItem('orderNumber') || '1000');
     let total = 0;
 
     // Inicializar si estamos en página de carrito (soporta rutas sin extensión)
@@ -153,12 +160,28 @@ document.addEventListener('DOMContentLoaded', () => {
             clearCartBtn.addEventListener('click', clearCart);
         }
 
-        // Código de descuento
-        const discountForm = document.getElementById('discount-form');
-        if (discountForm) {
-            discountForm.addEventListener('submit', (e) => {
+        // Selección de envío
+        const shippingOptions = document.querySelectorAll('input[name="shipping"]');
+        shippingOptions.forEach(opt => opt.addEventListener('change', () => {
+            selectedShipping = parseFloat(opt.value);
+            updateCartTotals();
+        }));
+
+        // Formulario de cupón
+        const couponForm = document.getElementById('coupon-form');
+        if (couponForm) {
+            couponForm.addEventListener('submit', (e) => {
                 e.preventDefault();
-                applyDiscount(e.target.querySelector('input').value);
+                applyDiscount(document.getElementById('coupon-code').value);
+            });
+        }
+
+        const updateBtn = document.getElementById('update-cart-btn');
+        if (updateBtn) {
+            updateBtn.addEventListener('click', () => {
+                saveCartToStorage();
+                updateCartTotals();
+                showNotification('Carrito actualizado', 'success');
             });
         }
     }
@@ -218,6 +241,8 @@ document.addEventListener('DOMContentLoaded', () => {
         }).then((result) => {
             if (result.isConfirmed) {
                 cartItems = [];
+                couponDiscount = 0;
+                localStorage.removeItem('welcomeCouponUsed');
                 saveCartToStorage();
                 renderCart();
                 updateCartTotals();
@@ -228,23 +253,25 @@ document.addEventListener('DOMContentLoaded', () => {
 
     // Aplicar descuento
     function applyDiscount(code) {
-        // Demo: código WELCOME10 da 10% de descuento
-        if (code.toUpperCase() === 'FASHION10') {
-            const discount = subtotal * 0.1;
-            total = subtotal + shipping - discount;
-            updateCartTotals(discount);
+        const role = localStorage.getItem('userRole') || 'cliente';
+        const used = localStorage.getItem('welcomeCouponUsed');
+        if (code.toUpperCase() === 'BIENVENIDA10' && (role === 'admin' || !used)) {
+            couponDiscount = subtotal * 0.1;
+            localStorage.setItem('welcomeCouponUsed', 'true');
             showNotification('¡Descuento aplicado!', 'success');
         } else {
-            showNotification('Código de descuento inválido', 'error');
+            couponDiscount = 0;
+            showNotification('Cupón inválido o ya usado', 'error');
         }
+        updateCartTotals();
     }
 
     // Actualizar totales del carrito con formato hondureño
-    function updateCartTotals(discount = 0) {
+    function updateCartTotals() {
         const totalItems = cartItems.reduce((sum, item) => sum + item.quantity, 0);
-        shipping = cartItems.length > 0 ? SHIPPING_RATE : 0;
+        shipping = cartItems.length > 0 ? selectedShipping : 0;
         subtotal = cartItems.reduce((sum, item) => sum + (item.price * item.quantity), 0);
-        total = subtotal + shipping - discount;
+        total = subtotal + shipping - couponDiscount;
 
         // Actualizar UI con formato hondureño
         const subtotalElement = document.getElementById('cart-subtotal');
@@ -254,7 +281,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
         if (subtotalElement) subtotalElement.textContent = `L. ${formatCurrencyHonduras(subtotal)}`;
         if (shippingElement) shippingElement.textContent = `L. ${formatCurrencyHonduras(shipping)}`;
-        if (discountElement) discountElement.textContent = `-L. ${formatCurrencyHonduras(discount)}`;
+        if (discountElement) {
+            discountElement.textContent = couponDiscount > 0 ? `-L. ${formatCurrencyHonduras(couponDiscount)}` : '-L. 0.00';
+            document.getElementById('discount-row').style.display = couponDiscount > 0 ? 'flex' : 'none';
+        }
         if (totalElement) totalElement.textContent = `L. ${formatCurrencyHonduras(total)}`;
 
         // Actualizar estado del botón de checkout
@@ -336,7 +366,9 @@ document.addEventListener('DOMContentLoaded', () => {
             });
 
             // Crear pedido con formato hondureño
-            const orderId = 'FC-' + Date.now();
+            orderNumber += 1;
+            localStorage.setItem('orderNumber', orderNumber.toString());
+            const orderId = 'FC-' + orderNumber;
             const order = {
                 id: orderId,
                 userId: userId,
@@ -386,7 +418,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 icon: 'success',
                 title: '¡Pedido enviado por WhatsApp!',
                 html: `
-                    <p>Tu pedido <strong>#${orderId.substring(0, 8)}</strong> ha sido enviado.</p>
+                    <p>Tu pedido <strong>#${orderId}</strong> ha sido enviado.</p>
                     <p>Se abrirá WhatsApp para completar tu pedido.</p>
                     <p><strong>Total: L. ${formatCurrencyHonduras(total)}</strong></p>
                     ${userId ? '<p class="text-success"><i class="fas fa-check"></i> Pedido guardado en tu perfil</p>' : '<p class="text-info"><i class="fas fa-info"></i> Inicia sesión para guardar tus pedidos</p>'}
@@ -419,7 +451,7 @@ document.addEventListener('DOMContentLoaded', () => {
         message += `👤 *Cliente:* ${order.userName}\n`;
         message += `📧 *Correo:* ${order.userEmail}\n`;
         message += `🗓️ *Fecha:* ${formatDateHonduras(new Date())}\n`;
-        message += `🆔 *Pedido:* #${order.id.substring(0, 8)}\n`;
+        message += `🆔 *Pedido:* #${order.id}\n`;
         if (savedOrderId) {
             message += `🔑 *ID Sistema:* ${savedOrderId}\n`;
         }


### PR DESCRIPTION
## Summary
- eliminar archivos de carrito duplicados
- añadir opciones de envío y campo de cupón en `carrito.html`
- integrar lógica de envío y descuentos en `js/cart.js`
- registrar número de pedido secuencial

## Testing
- `npm start` *(falla: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68657ab32de483228f562eb2d9a389bf