### PR TITLE
Enable custom ID on product creation

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -816,6 +816,10 @@
           <div class="modal-body">
             <form id="addProductForm">
               <div class="mb-3">
+                <label class="form-label">ID</label>
+                <input type="text" class="form-control" name="id" />
+              </div>
+              <div class="mb-3">
                 <label class="form-label">Nombre</label>
                 <input type="text" class="form-control" name="name" required />
               </div>

--- a/js/admin.js
+++ b/js/admin.js
@@ -1219,6 +1219,8 @@ function renderUsersTable() {
       e.preventDefault();
 
       const form = e.target;
+      // ID personalizado (opcional)
+      const customId = form.id.value.trim();
       const name = form.name.value.trim();
       const category = form.category.value;
       const price = parseFloat(form.price.value);
@@ -1408,7 +1410,17 @@ function renderUsersTable() {
           console.log('Producto actualizado:', productoEnEdicion.id);
         } else {
           newProduct.createdAt = new Date();
-          const docRef = await firebase.firestore().collection("products").add(newProduct);
+          // Si el usuario ingresa un ID se utiliza,
+          // de lo contrario generamos uno automático
+          let docRef;
+          if (customId) {
+            // Usamos el ID proporcionado
+            docRef = firebase.firestore().collection("products").doc(customId);
+          } else {
+            // Creamos un ID automático
+            docRef = firebase.firestore().collection("products").doc();
+          }
+          await docRef.set(newProduct);
           console.log('Producto creado:', docRef.id);
         }
 


### PR DESCRIPTION
## Summary
- allow administrators to especificar un identificador de producto
- guardar el producto usando doc(customId).set()

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6865916d412c83229057625c37e81985