### PR TITLE
Add category tips with themed backgrounds

### DIFF
--- a/acero.html
+++ b/acero.html
@@ -13,21 +13,74 @@
     <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth-compat.js"></script>
     <style>
-        /* Paleta de colores unificada */
+        /* Paleta de colores pastel en tonos rosados */
         :root {
-            --color-rose-gold: #bd8c7d;
-            --color-shimmer: #f4e4e1;
-            --color-nude: #e8c6b6;
-            --color-blush: #f7cac9;
-            --color-accent: #c06c84;
-            --color-deep-rose: #86424b;
+            --color-rose-gold: #f8c8dc;
+            --color-shimmer: #ffeaf4;
+            --color-nude: #fdd5e4;
+            --color-blush: #ffe6e9;
+            --color-accent: #eab5c4;
+            --color-deep-rose: #d48ca2;
         }
 
         /* Estilos base */
         body {
             font-family: 'Poppins', sans-serif;
-            background-color: #fff;
             color: #333;
+            position: relative;
+            overflow-x: hidden;
+        }
+
+        /* Fondo con degradado animado inspirado en maquillaje */
+        body::before {
+            content: '';
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: linear-gradient(45deg,
+                    var(--color-rose-gold),
+                    var(--color-shimmer),
+                    var(--color-blush),
+                    var(--color-accent));
+            background-size: 400% 400%;
+            z-index: -1;
+            animation: gradientMove 20s ease infinite;
+            opacity: 0.25;
+        }
+
+        @keyframes gradientMove {
+            0% { background-position: 0% 50%; }
+            50% { background-position: 100% 50%; }
+            100% { background-position: 0% 50%; }
+        }
+
+        .makeup-decorations {
+            pointer-events: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            z-index: -1;
+        }
+
+        .floating-makeup {
+            position: fixed;
+            font-size: 2rem;
+            opacity: 0.1;
+            animation: float 8s ease-in-out infinite;
+        }
+
+        .lipstick { top: 20%; left: 10%; animation-delay: 0s; }
+        .brush { top: 60%; right: 15%; animation-delay: 2s; }
+        .compact { bottom: 30%; left: 20%; animation-delay: 4s; }
+        .sparkle { top: 40%; right: 30%; animation-delay: 6s; }
+
+        @keyframes float {
+            0%,100% { transform: translateY(0) rotate(0deg); }
+            50% { transform: translateY(-20px) rotate(180deg); }
         }
 
         /* Encabezado degradado */
@@ -119,6 +172,13 @@
     </style>
 </head>
 <body>
+    <!-- Íconos flotantes para decorar la página -->
+    <div class="makeup-decorations">
+        <i class="fas fa-heart floating-makeup lipstick"></i>
+        <i class="fas fa-magic floating-makeup brush"></i>
+        <i class="fas fa-gem floating-makeup compact"></i>
+        <i class="fas fa-star floating-makeup sparkle"></i>
+    </div>
     <!-- Navbar -->
     <nav class="navbar navbar-expand-lg navbar-light sticky-top">
         <div class="container">
@@ -180,6 +240,11 @@
                         <option value="price-asc">Precio: menor a mayor</option>
                         <option value="price-desc">Precio: mayor a menor</option>
                     </select>
+                </div>
+                <div class="col-md-3">
+                    <button class="btn btn-primary w-100" id="tipBtn">
+                        <i class="fas fa-lightbulb me-1"></i> Tip de Acero
+                    </button>
                 </div>
             </div>
         </div>
@@ -307,6 +372,19 @@
                 el.style.display = totalItems > 0 ? 'inline' : 'none';
             });
         }
+
+        // Consejos para el cuidado del acero
+        const tips = [
+            'Limpia las piezas con agua tibia y jabón neutro.',
+            'Guarda tu joyería de acero por separado para evitar rayones.',
+            'Evita el contacto con productos químicos fuertes.',
+            'Seca bien el acero después de mojarlo para prevenir manchas.'
+        ];
+
+        document.getElementById('tipBtn').addEventListener('click', () => {
+            const tip = tips[Math.floor(Math.random() * tips.length)];
+            Swal.fire('Consejo de acero', tip, 'info');
+        });
     </script>
     <script type="module" src="js/maintenance.js"></script>
 </body>

--- a/acrilico.html
+++ b/acrilico.html
@@ -13,21 +13,74 @@
     <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth-compat.js"></script>
     <style>
-        /* Paleta de colores unificada */
+        /* Paleta de colores pastel en tonos rosados */
         :root {
-            --color-rose-gold: #bd8c7d;
-            --color-shimmer: #f4e4e1;
-            --color-nude: #e8c6b6;
-            --color-blush: #f7cac9;
-            --color-accent: #c06c84;
-            --color-deep-rose: #86424b;
+            --color-rose-gold: #f8c8dc;
+            --color-shimmer: #ffeaf4;
+            --color-nude: #fdd5e4;
+            --color-blush: #ffe6e9;
+            --color-accent: #eab5c4;
+            --color-deep-rose: #d48ca2;
         }
 
         /* Estilos base */
         body {
             font-family: 'Poppins', sans-serif;
-            background-color: #fff;
             color: #333;
+            position: relative;
+            overflow-x: hidden;
+        }
+
+        /* Fondo con degradado animado inspirado en maquillaje */
+        body::before {
+            content: '';
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: linear-gradient(45deg,
+                    var(--color-rose-gold),
+                    var(--color-shimmer),
+                    var(--color-blush),
+                    var(--color-accent));
+            background-size: 400% 400%;
+            z-index: -1;
+            animation: gradientMove 20s ease infinite;
+            opacity: 0.25;
+        }
+
+        @keyframes gradientMove {
+            0% { background-position: 0% 50%; }
+            50% { background-position: 100% 50%; }
+            100% { background-position: 0% 50%; }
+        }
+
+        .makeup-decorations {
+            pointer-events: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            z-index: -1;
+        }
+
+        .floating-makeup {
+            position: fixed;
+            font-size: 2rem;
+            opacity: 0.1;
+            animation: float 8s ease-in-out infinite;
+        }
+
+        .lipstick { top: 20%; left: 10%; animation-delay: 0s; }
+        .brush { top: 60%; right: 15%; animation-delay: 2s; }
+        .compact { bottom: 30%; left: 20%; animation-delay: 4s; }
+        .sparkle { top: 40%; right: 30%; animation-delay: 6s; }
+
+        @keyframes float {
+            0%,100% { transform: translateY(0) rotate(0deg); }
+            50% { transform: translateY(-20px) rotate(180deg); }
         }
 
         /* Encabezado degradado */
@@ -130,6 +183,13 @@
     </style>
 </head>
 <body>
+    <!-- Íconos flotantes para decorar la página -->
+    <div class="makeup-decorations">
+        <i class="fas fa-heart floating-makeup lipstick"></i>
+        <i class="fas fa-magic floating-makeup brush"></i>
+        <i class="fas fa-gem floating-makeup compact"></i>
+        <i class="fas fa-star floating-makeup sparkle"></i>
+    </div>
     <!-- Navbar -->
     <nav class="navbar navbar-expand-lg navbar-light sticky-top">
         <div class="container">
@@ -204,6 +264,11 @@
                         <option value="negro">Negro</option>
                         <option value="blanco">Blanco</option>
                     </select>
+                </div>
+                <div class="col-md-3">
+                    <button class="btn btn-primary w-100" id="tipBtn">
+                        <i class="fas fa-lightbulb me-1"></i> Tip de Acrílico
+                    </button>
                 </div>
             </div>
         </div>
@@ -449,13 +514,26 @@
         function updateCartCounter() {
             const cart = JSON.parse(localStorage.getItem('fashionCart') || '[]');
             const totalItems = cart.reduce((sum, item) => sum + item.quantity, 0);
-            
+
             const badges = document.querySelectorAll('.cart-badge, .cart-counter, .cart-count');
             badges.forEach(el => {
                 el.textContent = totalItems;
                 el.style.display = totalItems > 0 ? 'inline' : 'none';
             });
         }
+
+        // Consejos para productos acrílicos
+        const tips = [
+            'Limpia las piezas acrílicas con un paño suave para evitar rayones.',
+            'Evita exponer el acrílico a fuentes de calor intenso.',
+            'Lima suavemente los bordes para un acabado perfecto.',
+            'Guarda los artículos acrílicos en un lugar fresco y seco.'
+        ];
+
+        document.getElementById('tipBtn').addEventListener('click', () => {
+            const tip = tips[Math.floor(Math.random() * tips.length)];
+            Swal.fire('Consejo de acrílico', tip, 'info');
+        });
 
         // Actualizar contador al cargar
         document.addEventListener('DOMContentLoaded', updateCartCounter);

--- a/bisuteria.html
+++ b/bisuteria.html
@@ -261,7 +261,7 @@
                 </div>
                 <div class="col-md-3">
                     <button class="btn btn-primary w-100" id="tipBtn">
-                        <i class="fas fa-magic me-1"></i> Tip de Maquillaje
+                        <i class="fas fa-lightbulb me-1"></i> Tip de Bisutería
                     </button>
                 </div>
             </div>
@@ -542,17 +542,17 @@
         // Actualizar contador al cargar la página
         document.addEventListener('DOMContentLoaded', updateCartCounter);
 
-        // Mostrar un consejo de maquillaje al azar
+        // Mostrar un consejo de bisutería al azar
         const tips = [
-            'Aplica primero una prebase para prolongar la duración de tu maquillaje.',
-            'Utiliza brochas limpias para un acabado profesional.',
-            'Difumina bien las sombras para un look suave y elegante.',
-            'No olvides hidratar tu piel antes de maquillarte.'
+            'Usa ganchos de buena calidad para evitar reacciones en la piel.',
+            'Aplica esmalte transparente para mantener el brillo de tus accesorios.',
+            'Guarda tus collares colgados para que no se enreden.',
+            'Limpia cada pieza con un paño suave después de usarla.'
         ];
 
         document.getElementById('tipBtn').addEventListener('click', () => {
             const tip = tips[Math.floor(Math.random() * tips.length)];
-            Swal.fire('Consejo de maquillaje', tip, 'info');
+            Swal.fire('Consejo de bisutería', tip, 'info');
         });
     </script>
   <!--<script>

--- a/maquillaje.html
+++ b/maquillaje.html
@@ -15,21 +15,74 @@
     <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth-compat.js"></script>
     <style>
-        /* Variables de colores inspirados en maquillaje */
+        /* Paleta de colores pastel en tonos rosados */
         :root {
-            --color-rose-gold: #bd8c7d;
-            --color-shimmer: #f4e4e1;
-            --color-nude: #e8c6b6;
-            --color-blush: #f7cac9;
-            --color-accent: #c06c84;
-            --color-deep-rose: #86424b;
+            --color-rose-gold: #f8c8dc;
+            --color-shimmer: #ffeaf4;
+            --color-nude: #fdd5e4;
+            --color-blush: #ffe6e9;
+            --color-accent: #eab5c4;
+            --color-deep-rose: #d48ca2;
         }
 
         /* Estilos base */
         body {
             font-family: 'Poppins', sans-serif;
-            background-color: #fff;
             color: #333;
+            position: relative;
+            overflow-x: hidden;
+        }
+
+        /* Fondo con degradado animado inspirado en maquillaje */
+        body::before {
+            content: '';
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: linear-gradient(45deg,
+                    var(--color-rose-gold),
+                    var(--color-shimmer),
+                    var(--color-blush),
+                    var(--color-accent));
+            background-size: 400% 400%;
+            z-index: -1;
+            animation: gradientMove 20s ease infinite;
+            opacity: 0.25;
+        }
+
+        @keyframes gradientMove {
+            0% { background-position: 0% 50%; }
+            50% { background-position: 100% 50%; }
+            100% { background-position: 0% 50%; }
+        }
+
+        .makeup-decorations {
+            pointer-events: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            z-index: -1;
+        }
+
+        .floating-makeup {
+            position: fixed;
+            font-size: 2rem;
+            opacity: 0.1;
+            animation: float 8s ease-in-out infinite;
+        }
+
+        .lipstick { top: 20%; left: 10%; animation-delay: 0s; }
+        .brush { top: 60%; right: 15%; animation-delay: 2s; }
+        .compact { bottom: 30%; left: 20%; animation-delay: 4s; }
+        .sparkle { top: 40%; right: 30%; animation-delay: 6s; }
+
+        @keyframes float {
+            0%,100% { transform: translateY(0) rotate(0deg); }
+            50% { transform: translateY(-20px) rotate(180deg); }
         }
 
         /* Navbar con efecto cristal */
@@ -203,6 +256,13 @@
     </style>
 </head>
 <body>
+    <!-- Íconos flotantes para decorar la página -->
+    <div class="makeup-decorations">
+        <i class="fas fa-heart floating-makeup lipstick"></i>
+        <i class="fas fa-magic floating-makeup brush"></i>
+        <i class="fas fa-gem floating-makeup compact"></i>
+        <i class="fas fa-star floating-makeup sparkle"></i>
+    </div>
     <!-- Navbar -->
     <nav class="navbar navbar-expand-lg navbar-light sticky-top">
         <div class="container">
@@ -268,6 +328,11 @@
                 <div class="col-md-3">
                     <button class="btn btn-outline-secondary w-100 search-input" id="filterBtn">
                         <i class="fas fa-filter me-1"></i> Filtros
+                    </button>
+                </div>
+                <div class="col-md-3">
+                    <button class="btn btn-primary w-100" id="tipBtn">
+                        <i class="fas fa-lightbulb me-1"></i> Tip de Maquillaje
                     </button>
                 </div>
             </div>
@@ -573,13 +638,26 @@
         function updateCartCounter() {
             const cart = JSON.parse(localStorage.getItem('fashionCart') || '[]');
             const totalItems = cart.reduce((sum, item) => sum + item.quantity, 0);
-            
+
             const badges = document.querySelectorAll('.cart-badge, .cart-counter, .cart-count');
             badges.forEach(el => {
                 el.textContent = totalItems;
                 el.style.display = totalItems > 0 ? 'inline' : 'none';
             });
         }
+
+        // Consejos de maquillaje
+        const tips = [
+            'Aplica primero una prebase para prolongar la duración de tu maquillaje.',
+            'Utiliza brochas limpias para un acabado profesional.',
+            'Difumina bien las sombras para un look suave y elegante.',
+            'No olvides hidratar tu piel antes de maquillarte.'
+        ];
+
+        document.getElementById('tipBtn').addEventListener('click', () => {
+            const tip = tips[Math.floor(Math.random() * tips.length)];
+            Swal.fire('Consejo de maquillaje', tip, 'info');
+        });
 
         document.addEventListener('DOMContentLoaded', updateCartCounter);
     </script>

--- a/ofertas.html
+++ b/ofertas.html
@@ -13,21 +13,74 @@
     <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth-compat.js"></script>
     <style>
-        /* Paleta de colores unificada */
+        /* Paleta de colores pastel en tonos rosados */
         :root {
-            --color-rose-gold: #bd8c7d;
-            --color-shimmer: #f4e4e1;
-            --color-nude: #e8c6b6;
-            --color-blush: #f7cac9;
-            --color-accent: #c06c84;
-            --color-deep-rose: #86424b;
+            --color-rose-gold: #f8c8dc;
+            --color-shimmer: #ffeaf4;
+            --color-nude: #fdd5e4;
+            --color-blush: #ffe6e9;
+            --color-accent: #eab5c4;
+            --color-deep-rose: #d48ca2;
         }
 
         /* Estilos base */
         body {
             font-family: 'Poppins', sans-serif;
-            background-color: #fff;
             color: #333;
+            position: relative;
+            overflow-x: hidden;
+        }
+
+        /* Fondo con degradado animado inspirado en maquillaje */
+        body::before {
+            content: '';
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: linear-gradient(45deg,
+                    var(--color-rose-gold),
+                    var(--color-shimmer),
+                    var(--color-blush),
+                    var(--color-accent));
+            background-size: 400% 400%;
+            z-index: -1;
+            animation: gradientMove 20s ease infinite;
+            opacity: 0.25;
+        }
+
+        @keyframes gradientMove {
+            0% { background-position: 0% 50%; }
+            50% { background-position: 100% 50%; }
+            100% { background-position: 0% 50%; }
+        }
+
+        .makeup-decorations {
+            pointer-events: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            z-index: -1;
+        }
+
+        .floating-makeup {
+            position: fixed;
+            font-size: 2rem;
+            opacity: 0.1;
+            animation: float 8s ease-in-out infinite;
+        }
+
+        .lipstick { top: 20%; left: 10%; animation-delay: 0s; }
+        .brush { top: 60%; right: 15%; animation-delay: 2s; }
+        .compact { bottom: 30%; left: 20%; animation-delay: 4s; }
+        .sparkle { top: 40%; right: 30%; animation-delay: 6s; }
+
+        @keyframes float {
+            0%,100% { transform: translateY(0) rotate(0deg); }
+            50% { transform: translateY(-20px) rotate(180deg); }
         }
 
         /* Encabezado degradado */
@@ -152,6 +205,13 @@
     </style>
 </head>
 <body>
+    <!-- Íconos flotantes para decorar la página -->
+    <div class="makeup-decorations">
+        <i class="fas fa-heart floating-makeup lipstick"></i>
+        <i class="fas fa-magic floating-makeup brush"></i>
+        <i class="fas fa-gem floating-makeup compact"></i>
+        <i class="fas fa-star floating-makeup sparkle"></i>
+    </div>
     <!-- Navbar -->
     <nav class="navbar navbar-expand-lg navbar-light sticky-top">
         <div class="container">
@@ -257,6 +317,13 @@
                         <option value="price-asc">Menor precio</option>
                         <option value="price-desc">Mayor precio</option>
                     </select>
+                </div>
+            </div>
+            <div class="row mt-3">
+                <div class="col-md-3">
+                    <button class="btn btn-primary w-100" id="tipBtn">
+                        <i class="fas fa-lightbulb me-1"></i> Tip de Ofertas
+                    </button>
                 </div>
             </div>
         </div>
@@ -534,13 +601,26 @@
         function updateCartCounter() {
             const cart = JSON.parse(localStorage.getItem('fashionCart') || '[]');
             const totalItems = cart.reduce((sum, item) => sum + item.quantity, 0);
-            
+
             const badges = document.querySelectorAll('.cart-badge, .cart-counter, .cart-count');
             badges.forEach(el => {
                 el.textContent = totalItems;
                 el.style.display = totalItems > 0 ? 'inline' : 'none';
             });
         }
+
+        // Consejos para aprovechar las ofertas
+        const tips = [
+            'Revisa las fechas de vigencia de cada promoción.',
+            'Compara precios antes de comprar para aprovechar al máximo.',
+            'Suscríbete a nuestro boletín para recibir descuentos.',
+            'Aprovecha los productos con stock limitado rápidamente.'
+        ];
+
+        document.getElementById('tipBtn').addEventListener('click', () => {
+            const tip = tips[Math.floor(Math.random() * tips.length)];
+            Swal.fire('Consejo de ofertas', tip, 'info');
+        });
 
         function startCountdown() {
             // Establecer fecha de fin de oferta (7 días desde ahora)


### PR DESCRIPTION
## Summary
- add floating decorations and pastel gradient backgrounds
- show random tips for bisutería, acero, maquillaje, acrílico y ofertas

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867fbcd36e48322ab273fd2db4f8bbd