### PR TITLE
Apply pastel makeup style to perfil

### DIFF
--- a/perfil.html
+++ b/perfil.html
@@ -10,14 +10,51 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <!-- SweetAlert2 CSS -->
     <link href="https://cdn.jsdelivr.net/npm/@sweetalert2/theme-bootstrap-4/bootstrap-4.css" rel="stylesheet">
+    <!-- Google Fonts -->
+    <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Poppins:wght@300;400;500;600&display=swap" rel="stylesheet">
     <style>
+        :root {
+            --color-rose-gold: #f8c8dc;
+            --color-shimmer: #ffeaf4;
+            --color-nude: #fdd5e4;
+            --color-blush: #ffe6e9;
+            --color-accent: #eab5c4;
+            --color-deep-rose: #d48ca2;
+        }
+
         body {
-            background: linear-gradient(to right, #f8f9fa, #e9ecef);
-            font-family: 'Segoe UI', sans-serif;
+            font-family: 'Poppins', sans-serif;
+            color: #333;
+            position: relative;
+            overflow-x: hidden;
+        }
+
+        body::before {
+            content: '';
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: linear-gradient(45deg,
+                    var(--color-rose-gold),
+                    var(--color-shimmer),
+                    var(--color-blush),
+                    var(--color-accent));
+            background-size: 400% 400%;
+            z-index: -1;
+            animation: gradientMove 20s ease infinite;
+            opacity: 0.25;
+        }
+
+        @keyframes gradientMove {
+            0% { background-position: 0% 50%; }
+            50% { background-position: 100% 50%; }
+            100% { background-position: 0% 50%; }
         }
 
         .header {
-            background-color: #343a40;
+            background: linear-gradient(135deg, var(--color-rose-gold), var(--color-accent));
             color: white;
             position: sticky;
             top: 0;
@@ -45,7 +82,7 @@
             border-radius: 50%;
             margin-bottom: 1rem;
             object-fit: cover;
-            border: 3px solid #6a0dad;
+            border: 3px solid var(--color-accent);
             padding: 3px;
             transition: transform 0.3s;
         }
@@ -63,7 +100,7 @@
         }
 
         .nav-pills .nav-link.active {
-            background-color: #6a0dad;
+            background-color: var(--color-accent);
             color: white;
         }
 
@@ -78,12 +115,12 @@
         }
 
         .form-control:focus {
-            border-color: #6a0dad;
-            box-shadow: 0 0 0 0.2rem rgba(106, 13, 173, 0.25);
+            border-color: var(--color-accent);
+            box-shadow: 0 0 0 0.2rem rgba(234, 181, 196, 0.5);
         }
 
         .btn-primary {
-            background-color: #6a0dad;
+            background: linear-gradient(135deg, var(--color-accent), var(--color-deep-rose));
             border: none;
             border-radius: 50px;
             padding: 0.75rem 2rem;
@@ -92,13 +129,14 @@
         }
 
         .btn-primary:hover {
-            background-color: #5a0cb0;
             transform: translateY(-2px);
+            box-shadow: 0 4px 15px rgba(234, 181, 196, 0.5);
         }
 
         .order-card {
             border: none;
             border-radius: 12px;
+            background: #fff0f5;
             box-shadow: 0 2px 10px rgba(0,0,0,0.05);
             transition: transform 0.3s;
         }
@@ -134,7 +172,7 @@
 
         /* Estilos para las tarjetas de pedidos */
         .order-card {
-            background: #ffffff;
+            background: #fff0f5;
             border-radius: 10px;
             padding: 1.5rem;
             transition: transform 0.3s;
@@ -142,11 +180,46 @@
 
         .order-card:hover {
             transform: scale(1.02);
-            box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+            box-shadow: 0 4px 20px rgba(234, 181, 196, 0.3);
+        }
+
+        /* Decoraciones flotantes con íconos de maquillaje */
+        .makeup-decorations {
+            pointer-events: none;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            z-index: -1;
+        }
+
+        .floating-makeup {
+            position: fixed;
+            font-size: 2rem;
+            opacity: 0.1;
+            animation: float 8s ease-in-out infinite;
+        }
+
+        .lipstick { top: 20%; left: 10%; animation-delay: 0s; }
+        .brush { top: 60%; right: 15%; animation-delay: 2s; }
+        .compact { bottom: 30%; left: 20%; animation-delay: 4s; }
+        .sparkle { top: 40%; right: 30%; animation-delay: 6s; }
+
+        @keyframes float {
+            0%,100% { transform: translateY(0) rotate(0deg); }
+            50% { transform: translateY(-20px) rotate(180deg); }
         }
     </style>
 </head>
 <body>
+    <!-- Íconos flotantes de maquillaje para decorar la página -->
+    <div class="makeup-decorations">
+        <i class="fas fa-heart floating-makeup lipstick"></i>
+        <i class="fas fa-magic floating-makeup brush"></i>
+        <i class="fas fa-gem floating-makeup compact"></i>
+        <i class="fas fa-star floating-makeup sparkle"></i>
+    </div>
     <!-- Header -->
     <header class="header py-3">
         <div class="container">


### PR DESCRIPTION
## Summary
- redesign `perfil.html` with pastel colors
- add animated makeup background decorations
- tweak buttons and navigation with accent colors

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6868130d7cb483229b2477df3d603a8a