### PR TITLE
Save orders in user profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,9 @@ npm start
 El comando inicia `js/server.js`, que expone la aplicación en [http://localhost:8080](http://localhost:8080).
 
 Además de la página principal, el sitio cuenta con secciones de **Envíos**, **Devoluciones**, **Preguntas Frecuentes** y **Términos y Condiciones** accesibles desde el pie de página.
+
+## Gestión de pedidos
+
+Al realizar una compra desde el carrito, el pedido se guarda en Firebase Firestore. Cada pedido se almacena en la colección global `orders` y también dentro de `users/<UID>/orders` para que quede asociado a la cuenta del cliente.
+
+En la página **Mi Perfil** se muestran estos pedidos en la pestaña "Pedidos" y la información se actualiza en tiempo real cuando cambia su estado.

--- a/js/cart.js
+++ b/js/cart.js
@@ -410,6 +410,14 @@ document.addEventListener('DOMContentLoaded', () => {
                     const docRef = await firebase.firestore().collection('orders').add(order);
                     savedOrderId = docRef.id;
                     console.log('✅ Pedido guardado en Firebase con ID:', savedOrderId);
+
+                    // Guardar una copia en la subcolección del usuario
+                    await firebase.firestore()
+                        .collection('users')
+                        .doc(userId)
+                        .collection('orders')
+                        .doc(savedOrderId)
+                        .set({ id: savedOrderId, ...order });
                 } else if (!userId) {
                     console.log('⚠️ Usuario no autenticado, pedido no guardado en Firebase');
                 } else {

--- a/js/profile.js
+++ b/js/profile.js
@@ -24,6 +24,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const navbarUsername = document.getElementById('navbar-username');
 
     let currentUser = null;
+    let ordersUnsubscribe = null;
 
     // Inicializar perfil
     async function initializeProfile() {
@@ -115,28 +116,35 @@ document.addEventListener('DOMContentLoaded', () => {
     async function loadUserOrders() {
         try {
             console.log('📦 Cargando pedidos para usuario:', currentUser.uid);
-            
-            const snapshot = await firebase.firestore()
+
+            // Detener listener previo si existe
+            if (ordersUnsubscribe) {
+                ordersUnsubscribe();
+            }
+
+            ordersUnsubscribe = firebase.firestore()
                 .collection('orders')
                 .where('userId', '==', currentUser.uid)
                 .orderBy('createdAt', 'desc')
-                .get();
+                .onSnapshot(snapshot => {
+                    const orders = snapshot.docs.map(doc => {
+                        const data = doc.data();
+                        return {
+                            id: doc.id,
+                            ...data,
+                            createdAt: data.createdAt?.toDate() || new Date()
+                        };
+                    });
 
-            const orders = snapshot.docs.map(doc => {
-                const data = doc.data();
-                return {
-                    id: doc.id,
-                    ...data,
-                    createdAt: data.createdAt?.toDate() || new Date()
-                };
-            });
-
-            console.log(`📦 ${orders.length} pedidos encontrados`);
-            renderOrders(orders);
+                    console.log(`📦 ${orders.length} pedidos actualizados`);
+                    renderOrders(orders);
+                }, error => {
+                    console.error('❌ Error recibiendo pedidos:', error);
+                    renderOrders([]);
+                });
 
         } catch (error) {
             console.error('❌ Error cargando pedidos:', error);
-            // Si hay error, mostrar mensaje sin pedidos
             renderOrders([]);
         }
     }


### PR DESCRIPTION
## Summary
- store a copy of each order under `users/<uid>/orders`
- listen for realtime updates of orders in the profile page
- document the new order workflow

## Testing
- `node -c js/cart.js`
- `node -c js/profile.js`

------
https://chatgpt.com/codex/tasks/task_e_68682635d5888322a32bfec1606944ae