### PR TITLE
Fix order update when user subcollection missing

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -297,7 +297,7 @@ document.addEventListener("DOMContentLoaded", () => {
             .doc(pedido.userId)
             .collection("orders")
             .doc(pedidoId);
-          batch.update(userOrderRef, { status: "enviado" });
+          batch.set(userOrderRef, { status: "enviado" }, { merge: true });
         }
 
         await batch.commit();


### PR DESCRIPTION
## Summary
- handle missing user order document when marking order as shipped

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68682cff182c83229127ceaf29b28933