### PR TITLE
Save orders with consistent IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Además de la página principal, el sitio cuenta con secciones de **Envíos**, *
 
 ## Gestión de pedidos
 
-Al realizar una compra desde el carrito, el pedido se guarda en Firebase Firestore. Cada pedido se almacena en la colección global `orders` y también dentro de `users/<UID>/orders` para que quede asociado a la cuenta del cliente.
+Al realizar una compra desde el carrito, el pedido se guarda en Firebase Firestore. Cada pedido se almacena en la colección global `orders` y también dentro de `users/<UID>/orders` para que quede asociado a la cuenta del cliente. A partir de esta versión, el documento en Firestore utiliza como identificador el mismo código de pedido mostrado en el panel de administración (por ejemplo `FC-1001`).
 
 En la página **Mi Perfil** se muestran estos pedidos en la pestaña "Pedidos" y la información se actualiza en tiempo real cuando cambia su estado.
 

--- a/js/cart-enhanced.js
+++ b/js/cart-enhanced.js
@@ -2,6 +2,7 @@
 class EnhancedCart {
     constructor() {
         this.cart = this.loadCart();
+        this.orderNumber = parseInt(localStorage.getItem('orderNumber') || '1000');
         this.initializeEventListeners();
         this.updateCartDisplay();
     }
@@ -310,8 +311,14 @@ class EnhancedCart {
 
         if (result.isConfirmed) {
             try {
+                // Generar ID de pedido
+                this.orderNumber += 1;
+                localStorage.setItem('orderNumber', this.orderNumber.toString());
+                const orderId = 'FC-' + this.orderNumber;
+
                 // Crear pedido en Firebase
                 const order = {
+                    id: orderId,
                     userId: user.uid,
                     userEmail: user.email,
                     items: this.cart,
@@ -321,7 +328,10 @@ class EnhancedCart {
                     shippingAddress: null // Se puede agregar después
                 };
 
-                await firebase.firestore().collection('orders').add(order);
+                await firebase.firestore()
+                    .collection('orders')
+                    .doc(orderId)
+                    .set(order);
 
                 // Limpiar carrito
                 this.cart = [];

--- a/js/cart.js
+++ b/js/cart.js
@@ -407,8 +407,11 @@ document.addEventListener('DOMContentLoaded', () => {
             let savedOrderId = null;
             try {
                 if (typeof firebase !== 'undefined' && firebase.firestore && userId) {
-                    const docRef = await firebase.firestore().collection('orders').add(order);
-                    savedOrderId = docRef.id;
+                    await firebase.firestore()
+                        .collection('orders')
+                        .doc(orderId)
+                        .set(order);
+                    savedOrderId = orderId;
                     console.log('✅ Pedido guardado en Firebase con ID:', savedOrderId);
 
                     // Guardar una copia en la subcolección del usuario


### PR DESCRIPTION
## Summary
- create Firestore order docs using the custom order number
- keep order ID when saving in the user's subcollection
- track order counter in `cart-enhanced.js`
- document new behaviour in README

## Testing
- `node -c js/cart.js && node -c js/cart-enhanced.js`


------
https://chatgpt.com/codex/tasks/task_e_68682f381fac8322bb7ce216a777450a