### PR TITLE
Show user orders in profile

### DIFF
--- a/js/profile.js
+++ b/js/profile.js
@@ -14,7 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const profileGender = document.getElementById('profile-gender');
     const profileDisplayName = document.getElementById('profile-display-name');
     const profileEmailDisplay = document.getElementById('profile-email');
-    const ordersContainer = document.getElementById('orders-container');
+    const ordersContainer = document.getElementById('pedidosContainer');
     const addressesContainer = document.getElementById('addresses-container');
     const addressForm = document.getElementById('address-form');
     const addressLine = document.getElementById('address-line');
@@ -167,19 +167,20 @@ function renderOrders(orders) {
             return;
         }
 
-        ordersContainer.innerHTML = orders.map(order => `
-            <div class="col-md-4">
-                <div class="order-card">
-                    <h5 class="mb-3">Pedido #${order.id.substring(0, 8)}</h5>
-                    <p><strong>Fecha:</strong> ${formatDateHonduras(order.createdAt)}</p>
-                    <p><strong>Estado:</strong> <span class="status-badge bg-${getStatusColor(order.status)} text-white">${getStatusText(order.status)}</span></p>
-                    <p><strong>Total:</strong> L. ${formatCurrencyHonduras(order.total)}</p>
-                    <button class="btn btn-primary view-order-details" data-order-id="${order.id}">
-                        <i class="fas fa-eye me-1"></i>Ver Detalles
-                    </button>
+        ordersContainer.innerHTML = orders.map(order => {
+            const firstItem = order.items && order.items.length > 0 ? order.items[0] : null;
+            return `
+                <div class="col-md-4 col-sm-6">
+                    <div class="pedido-card">
+                        ${firstItem ? `<img src="${firstItem.image}" alt="${firstItem.name}">` : ''}
+                        <h6 class="mb-1">${firstItem ? firstItem.name : 'Pedido'}</h6>
+                        <p class="mb-1">Fecha: ${formatDateHonduras(order.createdAt)}</p>
+                        <p class="mb-1">Estado: <span class="status-badge bg-${getStatusColor(order.status)} text-white">${getStatusText(order.status)}</span></p>
+                        <p class="mb-0"><strong>Total:</strong> L. ${formatCurrencyHonduras(order.total)}</p>
+                    </div>
                 </div>
-            </div>
-        `).join('');
+            `;
+        }).join('');
     }
 
     // Cargar direcciones del usuario

--- a/perfil.html
+++ b/perfil.html
@@ -202,6 +202,27 @@
             box-shadow: 0 4px 20px rgba(234, 181, 196, 0.3);
         }
 
+        /* Nuevos estilos para la lista de pedidos */
+        .pedidos-lista .pedido-card {
+            background: #fff0f5;
+            border-radius: 10px;
+            padding: 1rem;
+            transition: transform 0.3s;
+        }
+
+        .pedidos-lista .pedido-card:hover {
+            transform: translateY(-4px);
+            box-shadow: 0 4px 15px rgba(234, 181, 196, 0.3);
+        }
+
+        .pedido-card img {
+            width: 100%;
+            height: 150px;
+            object-fit: cover;
+            border-radius: 8px;
+            margin-bottom: 0.5rem;
+        }
+
         /* Decoraciones flotantes con íconos de maquillaje */
         .makeup-decorations {
             pointer-events: none;
@@ -354,35 +375,7 @@
 
                     <!-- Orders Tab -->
                     <div class="tab-pane fade" id="orders">
-                        <div class="row g-4" id="orders-container">
-                            <div class="col-md-4">
-                                <div class="order-card p-3">
-                                    <h5 class="mb-3">Pedido #12345</h5>
-                                    <p><strong>Fecha:</strong> 2023-10-01</p>
-                                    <p><strong>Estado:</strong> <span class="status-badge bg-success text-white">Enviado</span></p>
-                                    <p><strong>Total:</strong> $99.99</p>
-                                    <a href="#" class="btn btn-primary">Ver Detalles</a>
-                                </div>
-                            </div>
-                            <div class="col-md-4">
-                                <div class="order-card p-3">
-                                    <h5 class="mb-3">Pedido #12346</h5>
-                                    <p><strong>Fecha:</strong> 2023-10-05</p>
-                                    <p><strong>Estado:</strong> <span class="status-badge bg-warning text-white">En Proceso</span></p>
-                                    <p><strong>Total:</strong> $49.99</p>
-                                    <a href="#" class="btn btn-primary">Ver Detalles</a>
-                                </div>
-                            </div>
-                            <div class="col-md-4">
-                                <div class="order-card p-3">
-                                    <h5 class="mb-3">Pedido #12347</h5>
-                                    <p><strong>Fecha:</strong> 2023-10-10</p>
-                                    <p><strong>Estado:</strong> <span class="status-badge bg-danger text-white">Cancelado</span></p>
-                                    <p><strong>Total:</strong> $29.99</p>
-                                    <a href="#" class="btn btn-primary">Ver Detalles</a>
-                                </div>
-                            </div>
-                        </div>
+                        <div id="pedidosContainer" class="row g-4 pedidos-lista"></div>
                     </div>
 
                     <!-- Addresses Tab -->


### PR DESCRIPTION
## Summary
- add container `pedidosContainer` for the orders tab
- style order list and cards
- load orders from Firestore and display product image, name, date, state and total

## Testing
- `npm start` *(fails: Cannot find module '/workspace/pagianwebfashion/js/server.js')*

------
https://chatgpt.com/codex/tasks/task_e_6869535251048322885e245a5bfe92e8