### PR TITLE
Fix status translation on profile page

### DIFF
--- a/js/profile.js
+++ b/js/profile.js
@@ -685,10 +685,15 @@ function renderOrders(orders) {
     function getStatusColor(status) {
         const statusColors = {
             'pending': 'warning',
+            'pendiente': 'warning',
             'processing': 'info',
+            'procesando': 'info',
             'shipped': 'primary',
+            'enviado': 'primary',
             'delivered': 'success',
-            'cancelled': 'danger'
+            'entregado': 'success',
+            'cancelled': 'danger',
+            'cancelado': 'danger'
         };
         return statusColors[status] || 'secondary';
     }
@@ -696,10 +701,15 @@ function renderOrders(orders) {
     function getStatusText(status) {
         const statusTexts = {
             'pending': 'Pendiente',
+            'pendiente': 'Pendiente',
             'processing': 'En Proceso',
+            'procesando': 'En Proceso',
             'shipped': 'Enviado',
+            'enviado': 'Enviado',
             'delivered': 'Entregado',
-            'cancelled': 'Cancelado'
+            'entregado': 'Entregado',
+            'cancelled': 'Cancelado',
+            'cancelado': 'Cancelado'
         };
         return statusTexts[status] || 'Desconocido';
     }


### PR DESCRIPTION
## Summary
- handle Spanish order statuses in the profile page

## Testing
- `npm test` *(fails: Missing script and network access)*

------
https://chatgpt.com/codex/tasks/task_e_6869611f41288322a1c689eba80a8342