### PR TITLE
Add pagination controls across categories

### DIFF
--- a/acero.html
+++ b/acero.html
@@ -380,6 +380,10 @@
                 <span class="visually-hidden">Cargando...</span>
             </div>
         </div>
+
+        <nav aria-label="Paginación" class="mt-4">
+            <ul class="pagination justify-content-center" id="pagination"></ul>
+        </nav>
     </div>
 
     <!-- Bootstrap Bundle with Popper -->
@@ -390,6 +394,10 @@
     <script src="js/firebase-config.js"></script>
     
     <script>
+        let allProducts = [];
+        let currentPage = 1;
+        const productsPerPage = 30;
+
         document.addEventListener('DOMContentLoaded', () => {
             loadProducts();
             updateCartCounter();
@@ -412,40 +420,99 @@
                 // Ocultar estado de carga
                 loadingState.style.display = 'none';
 
-                // Renderizar productos
-                let html = '';
-                snapshot.forEach(doc => {
-                    const product = doc.data();
-                    html += `
-                        <div>
-                            <div class="product-card">
-                                <div class="product-image">
-                                    <img src="${product.image || 'https://via.placeholder.com/300'}" alt="${product.name}">
-                                    <div class="price-badge">L.${product.price}</div>
-                                </div>
-                                <div class="product-info">
-                                    <h3 class="product-title">${product.name}</h3>
-                                    <p class="product-description">${product.description || ''}</p>
-                                    <div class="quantity-selector">
-                                        <button class="quantity-btn" onclick="decreaseQuantity(this)">-</button>
-                                        <input type="number" id="qty-${doc.id}" class="quantity-input" value="1" min="1">
-                                        <button class="quantity-btn" onclick="increaseQuantity(this)">+</button>
-                                    </div>
-                                    <button class="add-to-cart" onclick="addToCart('${doc.id}')">🛒 Agregar al Carrito</button>
-                                </div>
-                            </div>
-                        </div>
-                    `;
-                });
-
-                productsGrid.innerHTML = html || '<div class="col-12 text-center py-5">No se encontraron productos</div>';
+                allProducts = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+                currentPage = 1;
+                displayProducts();
 
             } catch (error) {
                 console.error('Error cargando productos:', error);
-                document.getElementById('productsGrid').innerHTML = 
+                document.getElementById('productsGrid').innerHTML =
                     '<div class="col-12 text-center py-5">Error cargando productos</div>';
             }
         }
+
+        function displayProducts() {
+            const productsGrid = document.getElementById('productsGrid');
+            const start = (currentPage - 1) * productsPerPage;
+            const end = start + productsPerPage;
+            const toShow = allProducts.slice(start, end);
+
+            productsGrid.innerHTML = '';
+
+            if (toShow.length === 0) {
+                productsGrid.innerHTML = '<div class="col-12 text-center py-5">No se encontraron productos</div>';
+                renderPagination(allProducts.length);
+                return;
+            }
+
+            toShow.forEach(product => {
+                const html = `
+                    <div>
+                        <div class="product-card">
+                            <div class="product-image">
+                                <img src="${product.image || 'https://via.placeholder.com/300'}" alt="${product.name}">
+                                <div class="price-badge">L.${product.price}</div>
+                            </div>
+                            <div class="product-info">
+                                <h3 class="product-title">${product.name}</h3>
+                                <p class="product-description">${product.description || ''}</p>
+                                <div class="quantity-selector">
+                                    <button class="quantity-btn" onclick="decreaseQuantity(this)">-</button>
+                                    <input type="number" id="qty-${product.id}" class="quantity-input" value="1" min="1">
+                                    <button class="quantity-btn" onclick="increaseQuantity(this)">+</button>
+                                </div>
+                                <button class="add-to-cart" onclick="addToCart('${product.id}')">🛒 Agregar al Carrito</button>
+                            </div>
+                        </div>
+                    </div>`;
+                productsGrid.insertAdjacentHTML('beforeend', html);
+            });
+
+            renderPagination(allProducts.length);
+        }
+
+        function renderPagination(totalItems) {
+            const pagination = document.getElementById('pagination');
+            if (!pagination) return;
+
+            const totalPages = Math.ceil(totalItems / productsPerPage);
+            if (totalPages <= 1) {
+                pagination.innerHTML = '';
+                return;
+            }
+
+            let html = `
+                <li class="page-item ${currentPage === 1 ? 'disabled' : ''}">
+                    <a class="page-link" href="#" data-page="${currentPage - 1}">Anterior</a>
+                </li>`;
+
+            for (let i = 1; i <= totalPages; i++) {
+                html += `
+                    <li class="page-item ${i === currentPage ? 'active' : ''}">
+                        <a class="page-link" href="#" data-page="${i}">${i}</a>
+                    </li>`;
+            }
+
+            html += `
+                <li class="page-item ${currentPage === totalPages ? 'disabled' : ''}">
+                    <a class="page-link" href="#" data-page="${currentPage + 1}">Siguiente</a>
+                </li>`;
+
+            pagination.innerHTML = html;
+        }
+
+        document.addEventListener('click', (e) => {
+            if (e.target.closest('#pagination .page-link')) {
+                e.preventDefault();
+                const page = parseInt(e.target.dataset.page);
+                const totalPages = Math.ceil(allProducts.length / productsPerPage);
+                if (!isNaN(page) && page >= 1 && page <= totalPages) {
+                    currentPage = page;
+                    displayProducts();
+                    window.scrollTo({ top: 0, behavior: 'smooth' });
+                }
+            }
+        });
 
         function addToCart(productId) {
             const qtyInput = document.getElementById('qty-' + productId);

--- a/acrilico.html
+++ b/acrilico.html
@@ -412,6 +412,10 @@
             <h4>No se encontraron productos</h4>
             <p class="text-muted">Prueba ajustando tus filtros de búsqueda</p>
         </div>
+
+        <nav aria-label="Paginación" class="mt-4">
+            <ul class="pagination justify-content-center" id="pagination"></ul>
+        </nav>
     </div>
 
     <!-- Bootstrap Bundle with Popper -->
@@ -423,6 +427,9 @@
     
     <script>
         let allProducts = [];
+        let filteredProducts = [];
+        let currentPage = 1;
+        const productsPerPage = 30;
         const productsGrid = document.getElementById('productsGrid');
         const loadingState = document.getElementById('loadingState');
         const emptyState = document.getElementById('emptyState');
@@ -460,11 +467,15 @@
                     allProducts = getDemoProducts();
                 }
 
-                displayProducts(allProducts);
+                filteredProducts = allProducts;
+                currentPage = 1;
+                displayProducts(filteredProducts);
             } catch (error) {
                 console.error('Error cargando productos:', error);
                 allProducts = getDemoProducts();
-                displayProducts(allProducts);
+                filteredProducts = allProducts;
+                currentPage = 1;
+                displayProducts(filteredProducts);
             } finally {
                 loadingState.style.display = 'none';
             }
@@ -542,20 +553,27 @@
                     break;
             }
             
-            displayProducts(filtered);
+            filteredProducts = filtered;
+            currentPage = 1;
+            displayProducts(filteredProducts);
         }
 
         function displayProducts(products) {
+            const start = (currentPage - 1) * productsPerPage;
+            const end = start + productsPerPage;
+            const toShow = products.slice(start, end);
+
             productsGrid.innerHTML = '';
-            
-            if (products.length === 0) {
+
+            if (toShow.length === 0) {
                 emptyState.style.display = 'block';
+                renderPagination(products.length);
                 return;
             }
-            
+
             emptyState.style.display = 'none';
-            
-            products.forEach(product => {
+
+            toShow.forEach(product => {
                 const productCard = document.createElement('div');
 
                 const imageUrl = product.image || product.imageUrl || 'https://images.unsplash.com/photo-1611652022419-a9419f74343d?w=300&h=300&fit=crop';
@@ -581,7 +599,52 @@
                 `;
                 productsGrid.appendChild(productCard);
             });
+
+            renderPagination(products.length);
         }
+
+        function renderPagination(totalItems) {
+            const pagination = document.getElementById('pagination');
+            if (!pagination) return;
+
+            const totalPages = Math.ceil(totalItems / productsPerPage);
+            if (totalPages <= 1) {
+                pagination.innerHTML = '';
+                return;
+            }
+
+            let html = `
+                <li class="page-item ${currentPage === 1 ? 'disabled' : ''}">
+                    <a class="page-link" href="#" data-page="${currentPage - 1}">Anterior</a>
+                </li>`;
+
+            for (let i = 1; i <= totalPages; i++) {
+                html += `
+                    <li class="page-item ${i === currentPage ? 'active' : ''}">
+                        <a class="page-link" href="#" data-page="${i}">${i}</a>
+                    </li>`;
+            }
+
+            html += `
+                <li class="page-item ${currentPage === totalPages ? 'disabled' : ''}">
+                    <a class="page-link" href="#" data-page="${currentPage + 1}">Siguiente</a>
+                </li>`;
+
+            pagination.innerHTML = html;
+        }
+
+        document.addEventListener('click', (e) => {
+            if (e.target.closest('#pagination .page-link')) {
+                e.preventDefault();
+                const page = parseInt(e.target.dataset.page);
+                const totalPages = Math.ceil(filteredProducts.length / productsPerPage);
+                if (!isNaN(page) && page >= 1 && page <= totalPages) {
+                    currentPage = page;
+                    displayProducts(filteredProducts);
+                    window.scrollTo({ top: 0, behavior: 'smooth' });
+                }
+            }
+        });
 
         function addToCart(productId) {
             const product = allProducts.find(p => p.id === productId);

--- a/bisuteria.html
+++ b/bisuteria.html
@@ -407,6 +407,10 @@
             <p class="text-muted">Prueba ajustando tus filtros de búsqueda</p>
         </div>
 
+        <nav aria-label="Paginación" class="mt-4">
+            <ul class="pagination justify-content-center" id="pagination"></ul>
+        </nav>
+
     </div>
 
     <!-- Footer -->
@@ -467,6 +471,9 @@
         let db;
         let isOffline = false;
         let allProducts = [];
+        let filteredProducts = [];
+        let currentPage = 1;
+        const productsPerPage = 30;
         const productsGrid = document.getElementById('productsGrid');
         const loadingSpinner = document.getElementById('loadingSpinner');
         const emptyState = document.getElementById('emptyState');
@@ -510,12 +517,16 @@
                     }));
                 }
                 
-                displayProducts(allProducts);
+                filteredProducts = allProducts;
+                currentPage = 1;
+                displayProducts(filteredProducts);
             } catch (error) {
                 console.error("Error cargando productos:", error);
                 // Fallback a productos demo
                 allProducts = getDemoProducts();
-                displayProducts(allProducts);
+                filteredProducts = allProducts;
+                currentPage = 1;
+                displayProducts(filteredProducts);
             } finally {
                 loadingSpinner.style.display = 'none';
             }
@@ -552,20 +563,27 @@
                     break;
             }
             
-            displayProducts(filtered);
+            filteredProducts = filtered;
+            currentPage = 1;
+            displayProducts(filteredProducts);
         }
 
         function displayProducts(products) {
+            const start = (currentPage - 1) * productsPerPage;
+            const end = start + productsPerPage;
+            const toShow = products.slice(start, end);
+
             productsGrid.innerHTML = '';
-            
-            if (products.length === 0) {
+
+            if (toShow.length === 0) {
                 emptyState.style.display = 'block';
+                renderPagination(products.length);
                 return;
             }
-            
+
             emptyState.style.display = 'none';
-            
-            products.forEach(product => {
+
+            toShow.forEach(product => {
                 const productCard = document.createElement('div');
 
                 const imageUrl = product.image || product.imageUrl || 'https://ivyottos.com/cdn/shop/articles/rs_w_1280_11.jpg?v=1628038418&width=1100';
@@ -593,7 +611,55 @@
                 `;
                 productsGrid.appendChild(productCard);
             });
+
+            renderPagination(products.length);
         }
+
+        function renderPagination(totalItems) {
+            const pagination = document.getElementById('pagination');
+            if (!pagination) return;
+
+            const totalPages = Math.ceil(totalItems / productsPerPage);
+            if (totalPages <= 1) {
+                pagination.innerHTML = '';
+                return;
+            }
+
+            let html = `
+                <li class="page-item ${currentPage === 1 ? 'disabled' : ''}">
+                    <a class="page-link" href="#" data-page="${currentPage - 1}">Anterior</a>
+                </li>
+            `;
+
+            for (let i = 1; i <= totalPages; i++) {
+                html += `
+                    <li class="page-item ${i === currentPage ? 'active' : ''}">
+                        <a class="page-link" href="#" data-page="${i}">${i}</a>
+                    </li>
+                `;
+            }
+
+            html += `
+                <li class="page-item ${currentPage === totalPages ? 'disabled' : ''}">
+                    <a class="page-link" href="#" data-page="${currentPage + 1}">Siguiente</a>
+                </li>
+            `;
+
+            pagination.innerHTML = html;
+        }
+
+        document.addEventListener('click', (e) => {
+            if (e.target.closest('#pagination .page-link')) {
+                e.preventDefault();
+                const page = parseInt(e.target.dataset.page);
+                const totalPages = Math.ceil(filteredProducts.length / productsPerPage);
+                if (!isNaN(page) && page >= 1 && page <= totalPages) {
+                    currentPage = page;
+                    displayProducts(filteredProducts);
+                    window.scrollTo({ top: 0, behavior: 'smooth' });
+                }
+            }
+        });
 
         // Función para agregar al carrito
         function addToCart(productId) {

--- a/js/products.js
+++ b/js/products.js
@@ -7,7 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
     let filteredProducts = [];
     let currentCategory = null;
     let currentPage = 1;
-    const productsPerPage = 12;
+    const productsPerPage = 30;
 
     // Inicializar si existe un contenedor para productos
     const productsArea = document.getElementById('products-container') ||

--- a/maquillaje.html
+++ b/maquillaje.html
@@ -480,21 +480,7 @@
 
         <!-- Paginación -->
         <nav aria-label="Navegación de páginas" class="mt-5">
-            <ul class="pagination justify-content-center" id="pagination">
-                <li class="page-item disabled">
-                    <a class="page-link" href="#" tabindex="-1" aria-disabled="true">
-                        <i class="fas fa-chevron-left"></i>
-                    </a>
-                </li>
-                <li class="page-item active"><a class="page-link" href="#">1</a></li>
-                <li class="page-item"><a class="page-link" href="#">2</a></li>
-                <li class="page-item"><a class="page-link" href="#">3</a></li>
-                <li class="page-item">
-                    <a class="page-link" href="#">
-                        <i class="fas fa-chevron-right"></i>
-                    </a>
-                </li>
-            </ul>
+            <ul class="pagination justify-content-center" id="pagination"></ul>
         </nav>
     </div>
 
@@ -558,6 +544,9 @@
         let db;
         let isOffline = false;
         let allProducts = [];
+        let filteredProducts = [];
+        let currentPage = 1;
+        const productsPerPage = 30;
         const productsGrid = document.getElementById('productsGrid');
         const loadingSpinner = document.getElementById('loadingSpinner');
         const emptyState = document.getElementById('emptyState');
@@ -598,11 +587,15 @@
                     }));
                 }
                 
-                displayProducts(allProducts);
+                filteredProducts = allProducts;
+                currentPage = 1;
+                displayProducts(filteredProducts);
             } catch (error) {
                 console.error("Error cargando productos:", error);
                 allProducts = getDemoProducts();
-                displayProducts(allProducts);
+                filteredProducts = allProducts;
+                currentPage = 1;
+                displayProducts(filteredProducts);
             } finally {
                 loadingSpinner.style.display = 'none';
             }
@@ -670,20 +663,27 @@
                     break;
             }
             
-            displayProducts(filtered);
+            filteredProducts = filtered;
+            currentPage = 1;
+            displayProducts(filteredProducts);
         }
 
         function displayProducts(products) {
+            const start = (currentPage - 1) * productsPerPage;
+            const end = start + productsPerPage;
+            const toShow = products.slice(start, end);
+
             productsGrid.innerHTML = '';
-            
-            if (products.length === 0) {
+
+            if (toShow.length === 0) {
                 emptyState.style.display = 'block';
+                renderPagination(products.length);
                 return;
             }
-            
+
             emptyState.style.display = 'none';
-            
-            products.forEach(product => {
+
+            toShow.forEach(product => {
                 const productCard = document.createElement('div');
 
                 const imageUrl = product.image || product.imageUrl || 'https://via.placeholder.com/300';
@@ -711,7 +711,52 @@
                 `;
                 productsGrid.appendChild(productCard);
             });
+
+            renderPagination(products.length);
         }
+
+        function renderPagination(totalItems) {
+            const pagination = document.getElementById('pagination');
+            if (!pagination) return;
+
+            const totalPages = Math.ceil(totalItems / productsPerPage);
+            if (totalPages <= 1) {
+                pagination.innerHTML = '';
+                return;
+            }
+
+            let html = `
+                <li class="page-item ${currentPage === 1 ? 'disabled' : ''}">
+                    <a class="page-link" href="#" data-page="${currentPage - 1}">Anterior</a>
+                </li>`;
+
+            for (let i = 1; i <= totalPages; i++) {
+                html += `
+                    <li class="page-item ${i === currentPage ? 'active' : ''}">
+                        <a class="page-link" href="#" data-page="${i}">${i}</a>
+                    </li>`;
+            }
+
+            html += `
+                <li class="page-item ${currentPage === totalPages ? 'disabled' : ''}">
+                    <a class="page-link" href="#" data-page="${currentPage + 1}">Siguiente</a>
+                </li>`;
+
+            pagination.innerHTML = html;
+        }
+
+        document.addEventListener('click', (e) => {
+            if (e.target.closest('#pagination .page-link')) {
+                e.preventDefault();
+                const page = parseInt(e.target.dataset.page);
+                const totalPages = Math.ceil(filteredProducts.length / productsPerPage);
+                if (!isNaN(page) && page >= 1 && page <= totalPages) {
+                    currentPage = page;
+                    displayProducts(filteredProducts);
+                    window.scrollTo({ top: 0, behavior: 'smooth' });
+                }
+            }
+        });
 
         function addToCart(productId) {
             const product = allProducts.find(p => p.id === productId);

--- a/novedades.html
+++ b/novedades.html
@@ -399,6 +399,10 @@
             <h4>No se encontraron novedades</h4>
             <p class="text-muted">Prueba ajustando tus filtros de búsqueda</p>
         </div>
+
+        <nav aria-label="Paginación" class="mt-4">
+            <ul class="pagination justify-content-center" id="pagination"></ul>
+        </nav>
     </div>
 
     <!-- Bootstrap Bundle with Popper -->
@@ -410,6 +414,9 @@
     
     <script>
         let allProducts = [];
+        let filteredProducts = [];
+        let currentPage = 1;
+        const productsPerPage = 30;
         const productsGrid = document.getElementById('productsGrid');
         const loadingState = document.getElementById('loadingState');
         const emptyState = document.getElementById('emptyState');
@@ -454,12 +461,16 @@
                     allProducts = getDemoProducts();
                 }
 
-                displayProducts(allProducts);
+                filteredProducts = allProducts;
+                currentPage = 1;
+                displayProducts(filteredProducts);
                 updateCategoryCounts();
             } catch (error) {
                 console.error('Error cargando novedades:', error);
                 allProducts = getDemoProducts();
-                displayProducts(allProducts);
+                filteredProducts = allProducts;
+                currentPage = 1;
+                displayProducts(filteredProducts);
                 updateCategoryCounts();
             } finally {
                 loadingState.style.display = 'none';
@@ -580,22 +591,29 @@
                     break;
             }
             
-            displayProducts(filtered);
+            filteredProducts = filtered;
+            currentPage = 1;
+            displayProducts(filteredProducts);
         }
 
         function displayProducts(products) {
+            const start = (currentPage - 1) * productsPerPage;
+            const end = start + productsPerPage;
+            const toShow = products.slice(start, end);
+
             // Mostrar cantidad total de artículos
             productCount.textContent = `${products.length} artículos`;
             productsGrid.innerHTML = '';
-            
-            if (products.length === 0) {
+
+            if (toShow.length === 0) {
                 emptyState.style.display = 'block';
+                renderPagination(products.length);
                 return;
             }
-            
+
             emptyState.style.display = 'none';
-            
-            products.forEach(product => {
+
+            toShow.forEach(product => {
                 const productCard = document.createElement('div');
 
                 const imageUrl = product.image || product.imageUrl || 'https://via.placeholder.com/300';
@@ -631,7 +649,52 @@
                 `;
                 productsGrid.appendChild(productCard);
             });
+
+            renderPagination(products.length);
         }
+
+        function renderPagination(totalItems) {
+            const pagination = document.getElementById('pagination');
+            if (!pagination) return;
+
+            const totalPages = Math.ceil(totalItems / productsPerPage);
+            if (totalPages <= 1) {
+                pagination.innerHTML = '';
+                return;
+            }
+
+            let html = `
+                <li class="page-item ${currentPage === 1 ? 'disabled' : ''}">
+                    <a class="page-link" href="#" data-page="${currentPage - 1}">Anterior</a>
+                </li>`;
+
+            for (let i = 1; i <= totalPages; i++) {
+                html += `
+                    <li class="page-item ${i === currentPage ? 'active' : ''}">
+                        <a class="page-link" href="#" data-page="${i}">${i}</a>
+                    </li>`;
+            }
+
+            html += `
+                <li class="page-item ${currentPage === totalPages ? 'disabled' : ''}">
+                    <a class="page-link" href="#" data-page="${currentPage + 1}">Siguiente</a>
+                </li>`;
+
+            pagination.innerHTML = html;
+        }
+
+        document.addEventListener('click', (e) => {
+            if (e.target.closest('#pagination .page-link')) {
+                e.preventDefault();
+                const page = parseInt(e.target.dataset.page);
+                const totalPages = Math.ceil(filteredProducts.length / productsPerPage);
+                if (!isNaN(page) && page >= 1 && page <= totalPages) {
+                    currentPage = page;
+                    displayProducts(filteredProducts);
+                    window.scrollTo({ top: 0, behavior: 'smooth' });
+                }
+            }
+        });
 
 function addToCart(productId) {
             const product = allProducts.find(p => p.id === productId);

--- a/ofertas.html
+++ b/ofertas.html
@@ -467,6 +467,10 @@
             <h4>No se encontraron ofertas</h4>
             <p class="text-muted">Prueba ajustando tus filtros de búsqueda</p>
         </div>
+
+        <nav aria-label="Paginación" class="mt-4">
+            <ul class="pagination justify-content-center" id="pagination"></ul>
+        </nav>
     </div>
 
     <!-- Bootstrap Bundle with Popper -->
@@ -478,6 +482,9 @@
     
     <script>
         let allProducts = [];
+        let filteredProducts = [];
+        let currentPage = 1;
+        const productsPerPage = 30;
         const productsGrid = document.getElementById('productsGrid');
         const loadingState = document.getElementById('loadingState');
         const emptyState = document.getElementById('emptyState');
@@ -519,11 +526,15 @@
                     allProducts = getDemoProducts();
                 }
 
-                displayProducts(allProducts);
+                filteredProducts = allProducts;
+                currentPage = 1;
+                displayProducts(filteredProducts);
             } catch (error) {
                 console.error('Error cargando ofertas:', error);
                 allProducts = getDemoProducts();
-                displayProducts(allProducts);
+                filteredProducts = allProducts;
+                currentPage = 1;
+                displayProducts(filteredProducts);
             } finally {
                 loadingState.style.display = 'none';
             }
@@ -620,20 +631,27 @@
                     break;
             }
             
-            displayProducts(filtered);
+            filteredProducts = filtered;
+            currentPage = 1;
+            displayProducts(filteredProducts);
         }
 
         function displayProducts(products) {
+            const start = (currentPage - 1) * productsPerPage;
+            const end = start + productsPerPage;
+            const toShow = products.slice(start, end);
+
             productsGrid.innerHTML = '';
-            
-            if (products.length === 0) {
+
+            if (toShow.length === 0) {
                 emptyState.style.display = 'block';
+                renderPagination(products.length);
                 return;
             }
-            
+
             emptyState.style.display = 'none';
-            
-            products.forEach(product => {
+
+            toShow.forEach(product => {
                 const productCard = document.createElement('div');
 
                 const imageUrl = product.image || product.imageUrl || 'https://via.placeholder.com/300';
@@ -662,7 +680,52 @@
                 `;
                 productsGrid.appendChild(productCard);
             });
+
+            renderPagination(products.length);
         }
+
+        function renderPagination(totalItems) {
+            const pagination = document.getElementById('pagination');
+            if (!pagination) return;
+
+            const totalPages = Math.ceil(totalItems / productsPerPage);
+            if (totalPages <= 1) {
+                pagination.innerHTML = '';
+                return;
+            }
+
+            let html = `
+                <li class="page-item ${currentPage === 1 ? 'disabled' : ''}">
+                    <a class="page-link" href="#" data-page="${currentPage - 1}">Anterior</a>
+                </li>`;
+
+            for (let i = 1; i <= totalPages; i++) {
+                html += `
+                    <li class="page-item ${i === currentPage ? 'active' : ''}">
+                        <a class="page-link" href="#" data-page="${i}">${i}</a>
+                    </li>`;
+            }
+
+            html += `
+                <li class="page-item ${currentPage === totalPages ? 'disabled' : ''}">
+                    <a class="page-link" href="#" data-page="${currentPage + 1}">Siguiente</a>
+                </li>`;
+
+            pagination.innerHTML = html;
+        }
+
+        document.addEventListener('click', (e) => {
+            if (e.target.closest('#pagination .page-link')) {
+                e.preventDefault();
+                const page = parseInt(e.target.dataset.page);
+                const totalPages = Math.ceil(filteredProducts.length / productsPerPage);
+                if (!isNaN(page) && page >= 1 && page <= totalPages) {
+                    currentPage = page;
+                    displayProducts(filteredProducts);
+                    window.scrollTo({ top: 0, behavior: 'smooth' });
+                }
+            }
+        });
 
         function addToCart(productId) {
             const product = allProducts.find(p => p.id === productId);


### PR DESCRIPTION
## Summary
- add pagination buttons to all category pages
- show 30 products per page
- implement pagination logic for category scripts
- adjust products.js default page size

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686989e7999083229ed6025dbfd05944