### PR TITLE
Integrate simple 3D model viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&family=Poppins:wght@300;400;500;600&display=swap" rel="stylesheet">
     <!-- TailwindCSS CDN -->
     <script src="https://cdn.tailwindcss.com"></script>
+    <script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
     <style>
         /* Comentarios en español para cada sección */
         
@@ -351,7 +352,7 @@
             </div>
             <div class="flex-1 relative">
                 <div class="bg-white shadow-xl rounded-3xl p-8 text-center relative">
-                    <img src="img/maquillaje.jpg" alt="Maquillaje" class="w-40 h-40 mx-auto rounded-full shadow-lg" />
+                    <model-viewer id="product-viewer" src="models/simple-triangle.gltf" alt="Modelo 3D" camera-controls auto-rotate class="w-40 h-40 mx-auto rounded-full shadow-lg" style="background: transparent;"></model-viewer>
                     <h3 class="text-xl font-bold text-gray-800 mt-4">Crema Facial de Rosa</h3>
                     <p class="text-gray-500">Crema nutritiva con extracto natural de rosa</p>
                 </div>
@@ -470,6 +471,7 @@
     <script src="js/cart.js"></script>
     <script src="js/orders.js"></script>
     <script src="js/app.js"></script>
+    <script src="js/model-viewer.js"></script>
     <script type="module" src="js/maintenance.js"></script>
     <script type="module">
         import { initializeApp } from "https://www.gstatic.com/firebasejs/9.6.10/firebase-app.js";

--- a/js/model-viewer.js
+++ b/js/model-viewer.js
@@ -1,0 +1,9 @@
+// Opciones básicas para el visor 3D
+window.addEventListener('DOMContentLoaded', () => {
+  const viewer = document.getElementById('product-viewer');
+  if (viewer) {
+    // Aumentar la intensidad de la luz y activar la animación de rotación
+    viewer.setAttribute('exposure', '1');
+    viewer.setAttribute('shadow-intensity', '1');
+  }
+});

--- a/models/simple-triangle.gltf
+++ b/models/simple-triangle.gltf
@@ -1,0 +1,27 @@
+{
+  "asset": { "version": "2.0" },
+  "scenes": [ { "nodes": [0] } ],
+  "nodes": [ { "mesh": 0 } ],
+  "meshes": [ {
+    "primitives": [ {
+      "attributes": { "POSITION": 0 }
+    } ]
+  } ],
+  "buffers": [ {
+    "uri": "data:application/octet-stream;base64,AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAA",
+    "byteLength": 36
+  } ],
+  "bufferViews": [ {
+    "buffer": 0,
+    "byteOffset": 0,
+    "byteLength": 36
+  } ],
+  "accessors": [ {
+    "bufferView": 0,
+    "componentType": 5126,
+    "count": 3,
+    "type": "VEC3",
+    "max": [1.0,1.0,0.0],
+    "min": [0.0,0.0,0.0]
+  } ]
+}


### PR DESCRIPTION
## Summary
- include model-viewer library in `index.html`
- replace hero product image with a model-viewer element
- load a minimal public domain GLTF model under `models/`
- add a small script to tweak lighting options

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a0047197083229bce4ca0d886459e