### PR TITLE
Add 3D makeup models and fancy header

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,15 @@
             z-index: 1020;
             box-shadow: 0 4px 30px rgba(0,0,0,0.1);
         }
+
+        /* Encabezado moderno para una apariencia más atractiva */
+        .fancy-header {
+            background: linear-gradient(90deg, #fcd3e1 0%, #fbc2eb 50%, #a6c1ee 100%);
+            color: #4b4b4b;
+            box-shadow: 0 8px 20px rgba(0,0,0,0.1);
+            border-bottom-left-radius: 1rem;
+            border-bottom-right-radius: 1rem;
+        }
         
         /* Tarjetas de categorías con efecto de brillo */
         .category-card {
@@ -287,7 +296,7 @@
 </head>
 <body>
     <!-- Header -->
-    <header class="bg-gradient-to-br from-pink-300 via-rose-200 to-orange-200 sticky top-0 z-50 shadow">
+    <header class="fancy-header sticky top-0 z-50">
         <div class="container mx-auto px-4 flex justify-between items-center py-4">
             <div class="flex items-center">
                 <a class="navbar-brand me-5 text-gray-800 font-bold text-xl" href="index.html">Fashion Collection</a>
@@ -352,7 +361,8 @@
             </div>
             <div class="flex-1 relative">
                 <div class="bg-white shadow-xl rounded-3xl p-8 text-center relative">
-                    <model-viewer id="product-viewer" src="models/simple-triangle.gltf" alt="Modelo 3D" camera-controls auto-rotate class="w-40 h-40 mx-auto rounded-full shadow-lg" style="background: transparent;"></model-viewer>
+                    <model-viewer id="product-viewer" src="models/lipstick.gltf" alt="Maquillaje 3D" camera-controls auto-rotate class="w-40 h-40 mx-auto rounded-full shadow-lg" style="background: transparent;"></model-viewer>
+                    <model-viewer src="models/compact.gltf" alt="Polvo compacto 3D" camera-controls auto-rotate class="w-32 h-32 mx-auto mt-4 rounded-full shadow" style="background: transparent;"></model-viewer>
                     <h3 class="text-xl font-bold text-gray-800 mt-4">Crema Facial de Rosa</h3>
                     <p class="text-gray-500">Crema nutritiva con extracto natural de rosa</p>
                 </div>

--- a/maquillaje.html
+++ b/maquillaje.html
@@ -14,6 +14,7 @@
     <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-app-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-firestore-compat.js"></script>
     <script src="https://www.gstatic.com/firebasejs/9.6.10/firebase-auth-compat.js"></script>
+    <script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>
     <style>
         /* Paleta de colores pastel en tonos rosados */
         :root {
@@ -100,6 +101,15 @@
             margin-bottom: 2rem;
             position: relative;
             overflow: hidden;
+        }
+
+        /* Versión mejorada del encabezado */
+        .fancy-header {
+            background: linear-gradient(90deg, #fcd3e1 0%, #fbc2eb 50%, #a6c1ee 100%);
+            color: #4b4b4b;
+            box-shadow: 0 8px 20px rgba(0,0,0,0.1);
+            border-bottom-left-radius: 1rem;
+            border-bottom-right-radius: 1rem;
         }
 
         .header::after {
@@ -417,9 +427,10 @@
     </nav>
 
     <!-- Header -->
-    <div class="header text-center">
+    <div class="header text-center fancy-header">
         <div class="container">
             <h1 class="display-4 fw-bold mb-3" style="font-family: 'Playfair Display', serif;">Maquillaje</h1>
+            <model-viewer src="models/lipstick.gltf" alt="Maquillaje 3D" camera-controls auto-rotate class="w-32 h-32 mx-auto my-3" style="background: transparent;"></model-viewer>
             <p class="lead">Descubre nuestra colección de productos de belleza de alta calidad</p>
         </div>
     </div>

--- a/models/compact.gltf
+++ b/models/compact.gltf
@@ -1,0 +1,27 @@
+{
+  "asset": { "version": "2.0" },
+  "scenes": [ { "nodes": [0] } ],
+  "nodes": [ { "mesh": 0 } ],
+  "meshes": [ {
+    "primitives": [ {
+      "attributes": { "POSITION": 0 }
+    } ]
+  } ],
+  "buffers": [ {
+    "uri": "data:application/octet-stream;base64,AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAA",
+    "byteLength": 36
+  } ],
+  "bufferViews": [ {
+    "buffer": 0,
+    "byteOffset": 0,
+    "byteLength": 36
+  } ],
+  "accessors": [ {
+    "bufferView": 0,
+    "componentType": 5126,
+    "count": 3,
+    "type": "VEC3",
+    "max": [1.0,1.0,0.0],
+    "min": [0.0,0.0,0.0]
+  } ]
+}

--- a/models/lipstick.gltf
+++ b/models/lipstick.gltf
@@ -1,0 +1,27 @@
+{
+  "asset": { "version": "2.0" },
+  "scenes": [ { "nodes": [0] } ],
+  "nodes": [ { "mesh": 0 } ],
+  "meshes": [ {
+    "primitives": [ {
+      "attributes": { "POSITION": 0 }
+    } ]
+  } ],
+  "buffers": [ {
+    "uri": "data:application/octet-stream;base64,AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAA",
+    "byteLength": 36
+  } ],
+  "bufferViews": [ {
+    "buffer": 0,
+    "byteOffset": 0,
+    "byteLength": 36
+  } ],
+  "accessors": [ {
+    "bufferView": 0,
+    "componentType": 5126,
+    "count": 3,
+    "type": "VEC3",
+    "max": [1.0,1.0,0.0],
+    "min": [0.0,0.0,0.0]
+  } ]
+}


### PR DESCRIPTION
## Summary
- add placeholder 3D models (`lipstick.gltf`, `compact.gltf`)
- enhance header styling via new `fancy-header` class
- show 3D makeup examples on the home hero section
- display a 3D model on the makeup page header

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a03ee1c908322b86f99085ec6ae9b