### PR TITLE
Improve dashboard charts and UI

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -83,7 +83,7 @@
 
       #sidebar ul li a:hover,
       #sidebar ul li a.active {
-        background: #6a0dad;
+        background: #0b3d91;
       }
 
       #sidebar ul li a i {
@@ -157,18 +157,18 @@
       }
 
       .form-control:focus {
-        border-color: #6a0dad;
-        box-shadow: 0 0 0 0.2rem rgba(106, 13, 173, 0.25);
+        border-color: #0b3d91;
+        box-shadow: 0 0 0 0.2rem rgba(11, 61, 145, 0.25);
       }
 
       /* Button Styles */
       .btn-primary {
-        background-color: #6a0dad;
+        background-color: #0b3d91;
         border: none;
       }
 
       .btn-primary:hover {
-        background-color: #5a0cb0;
+        background-color: #08295d;
       }
 
       /* Estilo de degradado para el encabezado del panel */

--- a/css/style.css
+++ b/css/style.css
@@ -41,7 +41,7 @@
 }
 
 .glass-header nav a:hover {
-  color: #ec4899;
+  color: #0b3d91;
 }
 
 .search-bar {

--- a/js/admin.js
+++ b/js/admin.js
@@ -8,6 +8,7 @@ document.addEventListener("DOMContentLoaded", () => {
   let products = [];
   let orders = [];
   let groupedOrders = {};
+  let accordionState = {};
   let orderFilters = { status: '', search: '', period: '' };
   let users = [];
   let productoEnEdicion = null;
@@ -1233,14 +1234,20 @@ function renderUsersTable() {
   function initDashboardCharts() {
     const ordersCtx = document.getElementById('graficaOrdenes');
     if (ordersCtx && window.Chart) {
+      const orderCounts = [0,0,0,0,0,0,0];
+      orders.forEach(o => {
+        const d = o.createdAt?.seconds ? new Date(o.createdAt.seconds * 1000) : new Date();
+        const day = (d.getDay() + 6) % 7;
+        orderCounts[day]++;
+      });
       new Chart(ordersCtx.getContext('2d'), {
         type: 'bar',
         data: {
           labels: ['Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb', 'Dom'],
           datasets: [{
             label: 'Pedidos',
-            data: [5, 8, 3, 6, 4, 7, 2],
-            backgroundColor: 'rgba(106,13,173,0.5)',
+            data: orderCounts,
+            backgroundColor: 'rgba(11,61,145,0.5)',
             borderRadius: 4
           }]
         },
@@ -1250,15 +1257,23 @@ function renderUsersTable() {
 
     const salesCtx = document.getElementById('graficaVentas');
     if (salesCtx && window.Chart) {
+      const weeklyTotals = [0,0,0,0];
+      orders.forEach(o => {
+        if(!o.createdAt?.seconds) return;
+        const d = new Date(o.createdAt.seconds * 1000);
+        const w = Math.min(getWeekOfMonth(d)-1,3);
+        const total = o.total || (o.items?.reduce((s,i)=>s+i.price*i.quantity,0) || 0);
+        weeklyTotals[w] += total;
+      });
       new Chart(salesCtx.getContext('2d'), {
         type: 'line',
         data: {
           labels: ['Semana 1', 'Semana 2', 'Semana 3', 'Semana 4'],
           datasets: [{
             label: 'Ventas (L)',
-            data: [1500, 2200, 1800, 2500],
-            backgroundColor: 'rgba(66,193,156,0.2)',
-            borderColor: 'rgba(66,193,156,1)',
+            data: weeklyTotals,
+            backgroundColor: 'rgba(11,61,145,0.2)',
+            borderColor: 'rgba(11,61,145,1)',
             fill: true,
             tension: 0.4
           }]
@@ -1269,14 +1284,19 @@ function renderUsersTable() {
 
     const stockCtx = document.getElementById('graficaStock');
     if (stockCtx && window.Chart) {
+      let enStock=0,bajo=0,agotado=0;
+      products.forEach(p => {
+        const s = p.stock || 0;
+        if(s===0) agotado++; else if(s<=5) bajo++; else enStock++;
+      });
       new Chart(stockCtx.getContext('2d'), {
         type: 'doughnut',
         data: {
           labels: ['En Stock', 'Bajo', 'Agotado'],
           datasets: [{
-            data: [80, 10, 10],
+            data: [enStock, bajo, agotado],
             backgroundColor: [
-              'rgba(106,13,173,0.6)',
+              'rgba(11,61,145,0.6)',
               'rgba(255,193,7,0.6)',
               'rgba(220,53,69,0.6)'
             ]
@@ -1285,6 +1305,11 @@ function renderUsersTable() {
         options: { responsive: true, animation: true }
       });
     }
+  }
+
+  function getWeekOfMonth(date) {
+    const firstDay = new Date(date.getFullYear(), date.getMonth(), 1).getDay();
+    return Math.ceil((date.getDate() + ((firstDay + 6) % 7)) / 7);
   }
   
   
@@ -1403,7 +1428,7 @@ function renderUsersTable() {
         const idx = `${c.prefix}${index}`;
         item.innerHTML = `
           <h2 class="accordion-header" id="heading${idx}">
-            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse${idx}" style="background-color:#6a0dad;color:white;">
+            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapse${idx}" style="background-color:#0b3d91;color:white;">
               ${nombre || email} (${pedidos.length} pedidos)
             </button>
           </h2>
@@ -1428,6 +1453,17 @@ function renderUsersTable() {
             </div>
           </div>`;
         c.el.appendChild(item);
+
+        const collapseEl = item.querySelector(`#collapse${idx}`);
+        if (accordionState[idx]) {
+          collapseEl.classList.add('show');
+        }
+        collapseEl.addEventListener('shown.bs.collapse', () => {
+          accordionState[idx] = true;
+        });
+        collapseEl.addEventListener('hidden.bs.collapse', () => {
+          accordionState[idx] = false;
+        });
       });
     });
   }

--- a/js/reports.js
+++ b/js/reports.js
@@ -156,7 +156,7 @@ function renderSalesChart(sales) {
             datasets: [{
                 label: 'Ventas',
                 data,
-                backgroundColor: '#6a0dad'
+                backgroundColor: '#0b3d91'
             }]
         },
         options: {
@@ -182,7 +182,7 @@ function renderCategoryChart(products) {
         type: 'doughnut',
         data: {
             labels,
-            datasets: [{ data, backgroundColor: ['#6a0dad', '#c06c84', '#bd8c7d', '#f4e4e1'] }]
+            datasets: [{ data, backgroundColor: ['#0b3d91', '#c06c84', '#bd8c7d', '#f4e4e1'] }]
         },
         options: {
             responsive: true,

--- a/js/settings.js
+++ b/js/settings.js
@@ -14,7 +14,7 @@ export class SystemSettings {
                 // Crear configuración por defecto
                 const defaultSettings = {
                     theme: {
-                        primaryColor: '#6a0dad',
+                        primaryColor: '#0b3d91',
                         secondaryColor: '#f8f9fa',
                         darkMode: false
                     },
@@ -301,7 +301,7 @@ export class SystemSettings {
                                 <form id="themeSettingsForm">
                                     <div class="mb-3">
                                         <label class="form-label">Color Primario</label>
-                                        <input type="color" class="form-control form-control-color" name="primaryColor" value="#6a0dad">
+                                        <input type="color" class="form-control form-control-color" name="primaryColor" value="#0b3d91">
                                     </div>
                                     <div class="mb-3">
                                         <label class="form-label">Color Secundario</label>
@@ -469,7 +469,7 @@ export function loadSettingsSection() {
             if (settings.theme) {
                 const themeForm = document.getElementById('themeSettingsForm');
                 if (themeForm) {
-                    themeForm.primaryColor.value = settings.theme.primaryColor || '#6a0dad';
+                    themeForm.primaryColor.value = settings.theme.primaryColor || '#0b3d91';
                     themeForm.secondaryColor.value = settings.theme.secondaryColor || '#f8f9fa';
                     themeForm.darkMode.checked = settings.theme.darkMode || false;
                 }


### PR DESCRIPTION
## Summary
- load colors from a darker blue palette
- compute dashboard charts using real order/product data
- persist accordion state when toggling orders

## Testing
- `npm test` *(fails: Missing script & network access)*

------
https://chatgpt.com/codex/tasks/task_e_686ec0c4314483229a9a554b54ad048d