### PR TITLE
Add map/calendar widgets and fix chart init

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -29,6 +29,16 @@
       rel="stylesheet"
       href="https://cdn.jsdelivr.net/npm/chart.js@3.9.1/dist/chart.min.css"
     />
+    <!-- Leaflet CSS -->
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    />
+    <!-- FullCalendar CSS -->
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/fullcalendar@5.11.5/main.min.css"
+    />
     <style>
       :root {
         --sidebar-width: 250px;
@@ -140,6 +150,14 @@
         box-shadow: var(--shadow);
         padding: 20px;
         margin-bottom: 20px;
+      }
+
+      #map {
+        height: 350px;
+      }
+
+      #calendar {
+        min-height: 350px;
       }
 
       /* Table Styles */
@@ -431,6 +449,20 @@
           <div class="col-md-4">
             <div class="chart-container">
               <canvas id="graficaStock"></canvas>
+            </div>
+          </div>
+        </div>
+
+        <!-- Map and Calendar -->
+        <div class="row mb-4">
+          <div class="col-md-6">
+            <div class="chart-container">
+              <div id="map"></div>
+            </div>
+          </div>
+          <div class="col-md-6">
+            <div class="chart-container">
+              <div id="calendar"></div>
             </div>
           </div>
         </div>
@@ -1552,6 +1584,11 @@
     <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script>
     <!-- Chart.js -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <!-- Leaflet JS -->
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <!-- FullCalendar JS -->
+    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@5.11.5/main.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/fullcalendar@5.11.5/locales-all.min.js"></script>
     <!-- html2pdf for PDF generation -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
     <!-- Firebase SDKs -->

--- a/js/admin.js
+++ b/js/admin.js
@@ -19,6 +19,11 @@ document.addEventListener("DOMContentLoaded", () => {
   let graficaOrdenesChart;
   let graficaVentasChart;
   let graficaStockChart;
+  let chartsInitialized = false;
+
+  // Instancias para mapa y calendario
+  let mapaDashboard;
+  let calendarioDashboard;
 
   // Importar módulos de reportes y configuración
   import('./reports.js').then(module => {
@@ -65,6 +70,8 @@ document.addEventListener("DOMContentLoaded", () => {
             loadDataFromFirebase();
             loadInventoryData();
             setupAdminEvents();
+            initMap();
+            initCalendar();
           } catch (error) {
             console.error('Error verificando rol:', error);
             redirectToLogin();
@@ -88,6 +95,8 @@ document.addEventListener("DOMContentLoaded", () => {
               loadDataFromFirebase();
               loadInventoryData();
               setupAdminEvents();
+              initMap();
+              initCalendar();
               console.log('✅ Acceso offline verificado');
               return;
             }
@@ -482,6 +491,9 @@ document.addEventListener("DOMContentLoaded", () => {
       groupOrders();
 
       renderDashboard();
+      if (!chartsInitialized) {
+        initDashboardCharts();
+      }
       renderOffersTable();
     } catch (error) {
       console.error("❌ Error cargando datos desde Firebase:", error);
@@ -1193,7 +1205,7 @@ function renderUsersTable() {
         monthlyRevenue: monthlyRevenue
       });
 
-      initDashboardCharts();
+
 
       // Renderizar tablas
       renderRecentOrdersTable();
@@ -1323,11 +1335,60 @@ function renderUsersTable() {
         options: { responsive: true, animation: true }
       });
     }
+
+    chartsInitialized = true;
   }
 
   function getWeekOfMonth(date) {
     const firstDay = new Date(date.getFullYear(), date.getMonth(), 1).getDay();
     return Math.ceil((date.getDate() + ((firstDay + 6) % 7)) / 7);
+  }
+
+  function initMap() {
+    const mapEl = document.getElementById('map');
+    if (!mapEl || typeof L === 'undefined') return;
+
+    if (mapaDashboard) {
+      mapaDashboard.remove();
+    }
+
+    mapaDashboard = L.map(mapEl).setView([15.5, -88.03], 13);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(mapaDashboard);
+
+    const lugares = [
+      { nombre: 'Galerías del Valle', coords: [15.5143, -88.019] },
+      { nombre: 'City Mall San Pedro Sula', coords: [15.4855, -88.0235] },
+      { nombre: 'Multiplaza San Pedro Sula', coords: [15.4997, -88.018] }
+    ];
+
+    lugares.forEach(l => {
+      L.marker(l.coords).addTo(mapaDashboard).bindPopup(`<b>${l.nombre}</b>`);
+    });
+  }
+
+  function initCalendar() {
+    const calendarEl = document.getElementById('calendar');
+    if (!calendarEl || typeof FullCalendar === 'undefined') return;
+
+    if (calendarioDashboard) {
+      calendarioDashboard.destroy();
+    }
+
+    calendarioDashboard = new FullCalendar.Calendar(calendarEl, {
+      locale: 'es',
+      initialView: 'dayGridMonth',
+      selectable: true,
+      dateClick(info) {
+        const titulo = prompt('Título del evento:');
+        if (titulo) {
+          calendarioDashboard.addEvent({ title: titulo, start: info.dateStr });
+        }
+      }
+    });
+
+    calendarioDashboard.render();
   }
   
   


### PR DESCRIPTION
## Summary
- integrate Leaflet map and FullCalendar widgets into dashboard
- include required CSS and JS for Leaflet and FullCalendar
- implement `initMap` and `initCalendar` functions in admin dashboard script
- prevent infinite loop in charts by destroying previous instances and ensuring charts initialize once

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ed526dae48322914f3dedae49c01a