### PR TITLE
Fix npm start for static site

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ Este proyecto es una demostración de la tienda en línea **Fashion Collection**
 
 ## Uso
 
-1. Instala las dependencias (opcional) con `npm install`.
-2. Sirve la carpeta del proyecto. Un método sencillo es:
+1. Sirve la carpeta del proyecto con un servidor estático. Un método sencillo es:
 
 ```bash
 npx http-server

--- a/package.json
+++ b/package.json
@@ -3,11 +3,9 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
-  "scripts": {
-    "start": "node js/server.js"
-  },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs"
 }
+


### PR DESCRIPTION
## Summary
- remove unused `start` script from package.json
- simplify the README usage instructions

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_686fe24ad7cc83228447630fe96e832c