### PR TITLE
Hide username in nav dropdown

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -175,13 +175,14 @@
             object-fit: cover;
         }
 
+        #navbar-username {
+            display: none;
+        }
+
         @media (max-width: 768px) {
             .profile-icon-btn {
                 width: 36px;
                 height: 36px;
-            }
-            #navbar-username {
-                display: none;
             }
         }
 

--- a/css/perfil.css
+++ b/css/perfil.css
@@ -311,13 +311,14 @@
             object-fit: cover;
         }
 
+        #navbar-username {
+            display: none;
+        }
+
         @media (max-width: 768px) {
             .profile-icon-btn {
                 width: 36px;
                 height: 36px;
-            }
-            #navbar-username {
-                display: none;
             }
         }
 


### PR DESCRIPTION
## Summary
- hide username text in the navbar on all pages so only the profile image shows

## Testing
- `npm install --prefix src/react` *(fails: internet disabled)*
- `npm run build --prefix src/react` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6876de35ca7c83229acf619503465e0f