### PR TITLE
Improve responsive navbar

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -7,8 +7,24 @@
             --color-nude: #e8c6b6;
             --color-blush: #f7cac9;
             --color-accent: #c06c84;
-        }
-        
+}
+
+/* Mostrar/ocultar opciones de carrito y perfil según tamaño de pantalla */
+@media (max-width: 768px) {
+    #cart-link-navbar,
+    #auth-buttons,
+    #profile-button {
+        display: none !important;
+    }
+}
+
+@media (min-width: 769px) {
+    #cart-link-offcanvas,
+    #auth-buttons-offcanvas,
+    #profile-button-offcanvas {
+        display: none !important;
+    }
+}
         /* Estilos generales del cuerpo */
         body {
             background-color: #fff;

--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
                 </nav>
             </div>
             <div class="flex items-center">
-                <a href="carrito.html" class="relative text-gray-800 me-4">
+                <a href="carrito.html" id="cart-link-navbar" class="relative text-gray-800 me-4">
                     <i class="fas fa-shopping-cart fa-lg"></i>
                     <span class="cart-badge absolute -top-2 -right-2 bg-pink-500 text-white rounded-full w-5 h-5 text-xs flex items-center justify-center">0</span>
                 </a>
@@ -79,7 +79,10 @@
                 <a class="block py-2 text-gray-800" href="novedades.html">Novedades</a>
                 <a class="block py-2 text-gray-800" href="galeria.html">Galería</a>
                 <a class="block py-2 text-gray-800" href="contacto.html">Contacto</a>
-                <a class="block py-2 text-gray-800" href="carrito.html"><i class="fas fa-shopping-cart me-2"></i>Carrito</a>
+                <a id="cart-link-offcanvas" class="block relative py-2 text-gray-800" href="carrito.html">
+                    <i class="fas fa-shopping-cart me-2"></i>Carrito
+                    <span class="cart-badge absolute -top-2 -right-2 bg-pink-500 text-white rounded-full w-5 h-5 text-xs flex items-center justify-center">0</span>
+                </a>
                 <hr>
                 <div id="auth-buttons-offcanvas" class="auth-buttons flex flex-col gap-2">
                     <a href="login.html">


### PR DESCRIPTION
## Summary
- move cart and profile elements into off‑canvas menu for small screens
- hide/show navbar and off‑canvas buttons with media queries

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687fabdbbaf48322b81f713e0410d998