### PR TITLE
Add alert for minimum cart items

### DIFF
--- a/js/cart.js
+++ b/js/cart.js
@@ -288,10 +288,8 @@ document.addEventListener('DOMContentLoaded', () => {
         if (totalElement) totalElement.textContent = `L. ${formatCurrencyHonduras(total)}`;
 
         // Actualizar estado del botón de checkout
-        const checkoutBtn = document.getElementById('checkout-btn');
-        if (checkoutBtn) {
-            checkoutBtn.disabled = totalItems < 3;
-        }
+        // No deshabilitamos el botón para poder mostrar un mensaje
+        // cuando el usuario intente proceder con menos de 3 artículos
     }
 
     // Actualizar badge del carrito
@@ -316,7 +314,7 @@ document.addEventListener('DOMContentLoaded', () => {
             await Swal.fire({
                 icon: 'info',
                 title: 'Añade más productos',
-                text: 'Debes agregar al menos 3 artículos para continuar'
+                text: 'Debes seleccionar la cantidad mínima de 3 artículos'
             });
             return;
         }


### PR DESCRIPTION
## Summary
- alert user if they attempt checkout with fewer than 3 items
- allow checkout button to stay enabled so message can show

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687fbc004db4832293dbf36fe138f03d