### PR TITLE
Enforce minimum quantity of three items

### DIFF
--- a/acero.html
+++ b/acero.html
@@ -185,8 +185,8 @@
                                 <h3 class="product-title">${product.name}</h3>
                                 <p class="product-description">${product.description || ''}</p>
                                 <div class="quantity-selector">
-                                    <button class="quantity-btn" onclick="decreaseQuantity(this)">-</button>
-                                    <input type="number" id="qty-${product.id}" class="quantity-input" value="1" min="1">
+                                    <button class="quantity-btn" onclick="decreaseQuantity(this)" disabled>-</button>
+                                    <input type="number" id="qty-${product.id}" class="quantity-input" value="3" min="3">
                                     <button class="quantity-btn" onclick="increaseQuantity(this)">+</button>
                                 </div>
                                 <button class="add-to-cart" onclick="addToCart('${product.id}')">🛒 Agregar al Carrito</button>
@@ -302,15 +302,23 @@
     <script type="module" src="js/maintenance.js"></script>
     <script>
     function increaseQuantity(button) {
-        const input = button.parentElement.querySelector('.quantity-input');
+        const selector = button.parentElement;
+        const input = selector.querySelector('.quantity-input');
         input.value = parseInt(input.value) + 1;
+        const minus = selector.querySelector('button');
+        if (minus) minus.disabled = parseInt(input.value) <= 3;
     }
 
     function decreaseQuantity(button) {
-        const input = button.parentElement.querySelector('.quantity-input');
-        if (parseInt(input.value) > 1) {
-            input.value = parseInt(input.value) - 1;
+        const selector = button.parentElement;
+        const input = selector.querySelector('.quantity-input');
+        const current = parseInt(input.value);
+        if (current > 3) {
+            input.value = current - 1;
+        } else {
+            Swal.fire('Tienes que seleccionar mínimo 3 artículos');
         }
+        button.disabled = parseInt(input.value) <= 3;
     }
     </script>
     <!-- Modal para imágenes de productos -->

--- a/acrilico.html
+++ b/acrilico.html
@@ -306,8 +306,8 @@
                             <h3 class="product-title">${product.name}</h3>
                             <p class="product-description">${(product.description || '').substring(0, 60)}${product.description && product.description.length > 60 ? '...' : ''}</p>
                             <div class="quantity-selector">
-                                <button class="quantity-btn" onclick="decreaseQuantity(this)">-</button>
-                                <input type="number" id="qty-${product.id}" class="quantity-input" value="1" min="1">
+                                <button class="quantity-btn" onclick="decreaseQuantity(this)" disabled>-</button>
+                                <input type="number" id="qty-${product.id}" class="quantity-input" value="3" min="3">
                                 <button class="quantity-btn" onclick="increaseQuantity(this)">+</button>
                             </div>
                             <button class="add-to-cart" onclick="addToCart('${product.id}')">🛒 Agregar al Carrito</button>
@@ -434,15 +434,23 @@
     <script type="module" src="js/maintenance.js"></script>
     <script>
     function increaseQuantity(button) {
-        const input = button.parentElement.querySelector('.quantity-input');
+        const selector = button.parentElement;
+        const input = selector.querySelector('.quantity-input');
         input.value = parseInt(input.value) + 1;
+        const minus = selector.querySelector('button');
+        if (minus) minus.disabled = parseInt(input.value) <= 3;
     }
 
     function decreaseQuantity(button) {
-        const input = button.parentElement.querySelector('.quantity-input');
-        if (parseInt(input.value) > 1) {
-            input.value = parseInt(input.value) - 1;
+        const selector = button.parentElement;
+        const input = selector.querySelector('.quantity-input');
+        const current = parseInt(input.value);
+        if (current > 3) {
+            input.value = current - 1;
+        } else {
+            Swal.fire('Tienes que seleccionar mínimo 3 artículos');
         }
+        button.disabled = parseInt(input.value) <= 3;
     }
     </script>
     <!-- Modal para imágenes de productos -->

--- a/bisuteria.html
+++ b/bisuteria.html
@@ -327,8 +327,8 @@
                             <h3 class="product-title">${product.name}</h3>
                             <p class="product-description">${(product.description || '').substring(0, 60)}${product.description && product.description.length > 60 ? '...' : ''}</p>
                             <div class="quantity-selector">
-                                <button class="quantity-btn" onclick="decreaseQuantity(this)">-</button>
-                                <input type="number" id="qty-${product.id}" class="quantity-input" value="1" min="1">
+                                <button class="quantity-btn" onclick="decreaseQuantity(this)" disabled>-</button>
+                                <input type="number" id="qty-${product.id}" class="quantity-input" value="3" min="3">
                                 <button class="quantity-btn" onclick="increaseQuantity(this)">+</button>
                             </div>
                             <button class="add-to-cart" onclick="addToCart('${product.id}')">🛒 Agregar al Carrito</button>
@@ -495,15 +495,23 @@
 <script type="module" src="js/maintenance.js"></script>
 <script>
 function increaseQuantity(button) {
-    const input = button.parentElement.querySelector('.quantity-input');
+    const selector = button.parentElement;
+    const input = selector.querySelector('.quantity-input');
     input.value = parseInt(input.value) + 1;
+    const minus = selector.querySelector('button');
+    if (minus) minus.disabled = parseInt(input.value) <= 3;
 }
 
 function decreaseQuantity(button) {
-    const input = button.parentElement.querySelector('.quantity-input');
-    if (parseInt(input.value) > 1) {
-        input.value = parseInt(input.value) - 1;
+    const selector = button.parentElement;
+    const input = selector.querySelector('.quantity-input');
+    const current = parseInt(input.value);
+    if (current > 3) {
+        input.value = current - 1;
+    } else {
+        Swal.fire('Tienes que seleccionar mínimo 3 artículos');
     }
+    button.disabled = parseInt(input.value) <= 3;
 }
 </script>
     <!-- Modal para imágenes de productos -->

--- a/css/acero.css
+++ b/css/acero.css
@@ -249,6 +249,11 @@
             background: #f9a1bb;
         }
 
+        .quantity-btn:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
         .quantity-input {
             width: 50px;
             text-align: center;

--- a/css/acrilico.css
+++ b/css/acrilico.css
@@ -260,6 +260,11 @@
             background: #f9a1bb;
         }
 
+        .quantity-btn:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
         .quantity-input {
             width: 50px;
             text-align: center;

--- a/css/bisuteria.css
+++ b/css/bisuteria.css
@@ -271,6 +271,11 @@
             background: #f9a1bb;
         }
 
+        .quantity-btn:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
         .quantity-input {
             width: 50px;
             text-align: center;

--- a/css/maquillaje.css
+++ b/css/maquillaje.css
@@ -340,6 +340,11 @@
             background: #f9a1bb;
         }
 
+        .quantity-btn:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
         .quantity-input {
             width: 50px;
             text-align: center;

--- a/css/novedades.css
+++ b/css/novedades.css
@@ -239,6 +239,11 @@
             background: #f9a1bb;
         }
 
+        .quantity-btn:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
         .quantity-input {
             width: 50px;
             text-align: center;

--- a/css/ofertas.css
+++ b/css/ofertas.css
@@ -282,6 +282,11 @@
             background: #f9a1bb;
         }
 
+        .quantity-btn:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
         .quantity-input {
             width: 50px;
             text-align: center;

--- a/maquillaje.html
+++ b/maquillaje.html
@@ -356,8 +356,8 @@
                             <h3 class="product-title">${product.name}</h3>
                             <p class="product-description">${(product.description || '').substring(0, 60)}${product.description && product.description.length > 60 ? '...' : ''}</p>
                             <div class="quantity-selector">
-                                <button class="quantity-btn" onclick="decreaseQuantity(this)">-</button>
-                                <input type="number" id="qty-${product.id}" class="quantity-input" value="1" min="1">
+                                <button class="quantity-btn" onclick="decreaseQuantity(this)" disabled>-</button>
+                                <input type="number" id="qty-${product.id}" class="quantity-input" value="3" min="3">
                                 <button class="quantity-btn" onclick="increaseQuantity(this)">+</button>
                             </div>
                             <button class="add-to-cart" onclick="addToCart('${product.id}')">🛒 Agregar al Carrito</button>
@@ -477,15 +477,23 @@
     <script type="module" src="js/maintenance.js"></script>
     <script>
     function increaseQuantity(button) {
-        const input = button.parentElement.querySelector('.quantity-input');
+        const selector = button.parentElement;
+        const input = selector.querySelector('.quantity-input');
         input.value = parseInt(input.value) + 1;
+        const minus = selector.querySelector('button');
+        if (minus) minus.disabled = parseInt(input.value) <= 3;
     }
 
     function decreaseQuantity(button) {
-        const input = button.parentElement.querySelector('.quantity-input');
-        if (parseInt(input.value) > 1) {
-            input.value = parseInt(input.value) - 1;
+        const selector = button.parentElement;
+        const input = selector.querySelector('.quantity-input');
+        const current = parseInt(input.value);
+        if (current > 3) {
+            input.value = current - 1;
+        } else {
+            Swal.fire('Tienes que seleccionar mínimo 3 artículos');
         }
+        button.disabled = parseInt(input.value) <= 3;
     }
     </script>
     <!-- Modal para imágenes de productos -->

--- a/novedades.html
+++ b/novedades.html
@@ -377,8 +377,8 @@
                             <h3 class="product-title">${product.name}</h3>
                             <p class="product-description">${(product.description || '').substring(0, 60)}${product.description && product.description.length > 60 ? '...' : ''}</p>
                             <div class="quantity-selector">
-                                <button class="quantity-btn" onclick="decreaseQuantity(this)">-</button>
-                                <input type="number" id="qty-${product.id}" class="quantity-input" value="1" min="1">
+                                <button class="quantity-btn" onclick="decreaseQuantity(this)" disabled>-</button>
+                                <input type="number" id="qty-${product.id}" class="quantity-input" value="3" min="3">
                                 <button class="quantity-btn" onclick="increaseQuantity(this)">+</button>
                             </div>
                             <button class="add-to-cart" onclick="addToCart('${product.id}')">🛒 Agregar al Carrito</button>
@@ -507,15 +507,23 @@ function addToCart(productId) {
     <script type="module" src="js/maintenance.js"></script>
     <script>
     function increaseQuantity(button) {
-        const input = button.parentElement.querySelector('.quantity-input');
+        const selector = button.parentElement;
+        const input = selector.querySelector('.quantity-input');
         input.value = parseInt(input.value) + 1;
+        const minus = selector.querySelector('button');
+        if (minus) minus.disabled = parseInt(input.value) <= 3;
     }
 
     function decreaseQuantity(button) {
-        const input = button.parentElement.querySelector('.quantity-input');
-        if (parseInt(input.value) > 1) {
-            input.value = parseInt(input.value) - 1;
+        const selector = button.parentElement;
+        const input = selector.querySelector('.quantity-input');
+        const current = parseInt(input.value);
+        if (current > 3) {
+            input.value = current - 1;
+        } else {
+            Swal.fire('Tienes que seleccionar mínimo 3 artículos');
         }
+        button.disabled = parseInt(input.value) <= 3;
     }
     </script>
     <!-- Modal para imágenes de productos -->

--- a/ofertas.html
+++ b/ofertas.html
@@ -365,8 +365,8 @@
                             <h3 class="product-title">${product.name}</h3>
                             <p class="product-description">${(product.description || '').substring(0, 60)}${product.description && product.description.length > 60 ? '...' : ''}</p>
                             <div class="quantity-selector">
-                                <button class="quantity-btn" onclick="decreaseQuantity(this)">-</button>
-                                <input type="number" id="qty-${product.id}" class="quantity-input" value="1" min="1">
+                                <button class="quantity-btn" onclick="decreaseQuantity(this)" disabled>-</button>
+                                <input type="number" id="qty-${product.id}" class="quantity-input" value="3" min="3">
                                 <button class="quantity-btn" onclick="increaseQuantity(this)">+</button>
                             </div>
                             <button class="add-to-cart" onclick="addToCart('${product.id}')">🛒 ¡Aprovechar Oferta!</button>
@@ -524,15 +524,23 @@
     <script type="module" src="js/maintenance.js"></script>
     <script>
     function increaseQuantity(button) {
-        const input = button.parentElement.querySelector('.quantity-input');
+        const selector = button.parentElement;
+        const input = selector.querySelector('.quantity-input');
         input.value = parseInt(input.value) + 1;
+        const minus = selector.querySelector('button');
+        if (minus) minus.disabled = parseInt(input.value) <= 3;
     }
 
     function decreaseQuantity(button) {
-        const input = button.parentElement.querySelector('.quantity-input');
-        if (parseInt(input.value) > 1) {
-            input.value = parseInt(input.value) - 1;
+        const selector = button.parentElement;
+        const input = selector.querySelector('.quantity-input');
+        const current = parseInt(input.value);
+        if (current > 3) {
+            input.value = current - 1;
+        } else {
+            Swal.fire('Tienes que seleccionar mínimo 3 artículos');
         }
+        button.disabled = parseInt(input.value) <= 3;
     }
     </script>
     <!-- Modal para imágenes de productos -->


### PR DESCRIPTION
## Summary
- set default quantity to 3 and disable minus button initially
- show warning when attempting to go below 3
- enable/disable the minus button dynamically
- style disabled quantity buttons consistently

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6883a86e772c8322b8ac54b4ba1332b4