### PR TITLE
Improve orders page style and remove accordion animation

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -310,7 +310,7 @@
           <div id="listaPedidos" class="accordion"></div>
 
           <div class="table-responsive">
-            <table class="table" id="orders-table">
+            <table class="table table-striped table-hover" id="orders-table">
               <thead>
                 <tr>
                   <th>ID</th>

--- a/css/admin.css
+++ b/css/admin.css
@@ -265,3 +265,26 @@
         background-color: #2a2a40;
         color: #f8f9fa;
       }
+
+/* Ordenes sin animaciones */
+#orders-section .accordion-collapse,
+#dashboard-section .accordion-collapse,
+#orders-section .collapse,
+#dashboard-section .collapse,
+#orders-section .collapsing,
+#dashboard-section .collapsing {
+  transition: none !important;
+}
+
+#orders-section .accordion-button:not(.collapsed) {
+  background-color: #092a63;
+  color: #fff;
+}
+#orders-section .accordion-button {
+  background-color: #0b3d91;
+  color: #fff;
+}
+#orders-section .table-hover tbody tr:hover {
+  background-color: var(--light-gray);
+}
+

--- a/js/admin.js
+++ b/js/admin.js
@@ -1640,7 +1640,7 @@ function renderUsersTable() {
           <div id="collapse${idx}" class="accordion-collapse collapse">
             <div class="accordion-body p-0">
               <div class="table-responsive">
-                <table class="table table-striped table-bordered mb-0">
+                <table class="table table-striped table-bordered table-hover mb-0">
                   <thead>
                     <tr>
                       <th>ID</th>


### PR DESCRIPTION
## Summary
- tweak admin orders table to use Bootstrap table styling
- remove collapse animation for order accordion lists
- apply new color styling for order accordion headers

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688cec9650608322babf7a6346eda7ed